### PR TITLE
Re #774, #776: update gem dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'rails', '4.2.4'
+gem 'rails', '4.2.5'
 
 gem 'europeana-styleguide', github: 'europeana/europeana-styleguide-ruby', ref: '2a5b6c7'
 
@@ -8,16 +8,13 @@ gem 'europeana-styleguide', github: 'europeana/europeana-styleguide-ruby', ref: 
 # @see https://github.com/agoragames/stache/pulls/rwd
 gem 'stache', github: 'europeana/stache', branch: 'europeana-styleguide'
 
-gem 'rails_admin_globalize_field', github: 'rwd/rails_admin_globalize_field',
-  branch: 'globalize-5-rails-4.2'
-
 gem 'aasm', '~> 4.2'
 gem 'actionpack-action_caching'
 gem 'blacklight', '~> 5.15'
 gem 'cancancan', '~> 1.12'
 gem 'clockwork', '~> 1.2'
 gem 'colorize'
-gem 'delayed_job_active_record', '~> 4.0.3'
+gem 'delayed_job_active_record', '~> 4.1'
 gem 'devise', '~> 3.5'
 gem 'europeana-blacklight', '~> 0.3.2'
 gem 'europeana-api', '~> 0.4.2'
@@ -25,14 +22,15 @@ gem 'feedjira', '~> 2.0'
 gem 'fog', '~> 1.33'
 gem 'globalize', '~> 5.0'
 gem 'globalize-versioning', github: 'globalize/globalize-versioning'
-gem 'htmlcompressor', '0.2'
-gem 'nokogiri', '~> 1.6.6.4'
+gem 'htmlcompressor', '0.3'
+gem 'nokogiri', '~> 1.6.7.1'
 gem 'pg'
 gem 'paperclip', '~> 4.3'
 gem 'paper_trail', '~> 4.0'
 gem 'puma', '~> 2.13'
 gem 'rack-rewrite'
-gem 'rails_admin', '~> 0.7.0'
+gem 'rails_admin', '~> 0.8.0'
+gem 'rails_admin_globalize_field', '~> 0.4'
 gem 'redis-rails', '~> 4.0'
 gem 'redis-rails-instrumentation'
 gem 'sass-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,53 +25,43 @@ GIT
       globalize (>= 3.0.4, < 6)
       paper_trail (>= 3.0.0, < 5)
 
-GIT
-  remote: git://github.com/rwd/rails_admin_globalize_field.git
-  revision: 59b87f63a1c017d5851f610cd7e6faefacd2dd03
-  branch: globalize-5-rails-4.2
-  specs:
-    rails_admin_globalize_field (0.3.3)
-      globalize (>= 5.0)
-      rails (>= 4.2)
-      rails_admin (>= 0.6.2)
-
 GEM
   remote: https://rubygems.org/
   specs:
     CFPropertyList (2.3.2)
     aasm (4.5.1)
-    actionmailer (4.2.4)
-      actionpack (= 4.2.4)
-      actionview (= 4.2.4)
-      activejob (= 4.2.4)
+    actionmailer (4.2.5)
+      actionpack (= 4.2.5)
+      actionview (= 4.2.5)
+      activejob (= 4.2.5)
       mail (~> 2.5, >= 2.5.4)
       rails-dom-testing (~> 1.0, >= 1.0.5)
-    actionpack (4.2.4)
-      actionview (= 4.2.4)
-      activesupport (= 4.2.4)
+    actionpack (4.2.5)
+      actionview (= 4.2.5)
+      activesupport (= 4.2.5)
       rack (~> 1.6)
       rack-test (~> 0.6.2)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
     actionpack-action_caching (1.1.1)
       actionpack (>= 4.0.0, < 5.0)
-    actionview (4.2.4)
-      activesupport (= 4.2.4)
+    actionview (4.2.5)
+      activesupport (= 4.2.5)
       builder (~> 3.1)
       erubis (~> 2.7.0)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
-    activejob (4.2.4)
-      activesupport (= 4.2.4)
+    activejob (4.2.5)
+      activesupport (= 4.2.5)
       globalid (>= 0.3.0)
-    activemodel (4.2.4)
-      activesupport (= 4.2.4)
+    activemodel (4.2.5)
+      activesupport (= 4.2.5)
       builder (~> 3.1)
-    activerecord (4.2.4)
-      activemodel (= 4.2.4)
-      activesupport (= 4.2.4)
+    activerecord (4.2.5)
+      activemodel (= 4.2.5)
+      activesupport (= 4.2.5)
       arel (~> 6.0)
-    activesupport (4.2.4)
+    activesupport (4.2.5)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
@@ -79,10 +69,10 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.4.0)
     arel (6.0.3)
-    ast (2.1.0)
+    ast (2.2.0)
     astrolabe (1.3.1)
       parser (~> 2.2)
-    autoprefixer-rails (6.1.2)
+    autoprefixer-rails (6.2.3)
       execjs
       json
     bcrypt (3.1.10)
@@ -116,9 +106,9 @@ GEM
       tzinfo
     cocaine (0.5.8)
       climate_control (>= 0.0.3, < 1.0)
-    coffee-rails (4.1.0)
+    coffee-rails (4.1.1)
       coffee-script (>= 2.2.0)
-      railties (>= 4.0.0, < 5.0)
+      railties (>= 4.0.0, < 5.1.x)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
@@ -135,14 +125,14 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     debug_inspector (0.0.2)
-    delayed_job (4.0.6)
+    delayed_job (4.1.1)
       activesupport (>= 3.0, < 5.0)
-    delayed_job_active_record (4.0.3)
-      activerecord (>= 3.0, < 5.0)
-      delayed_job (>= 3.0, < 4.1)
+    delayed_job_active_record (4.1.0)
+      activerecord (>= 3.0, < 5)
+      delayed_job (>= 3.0, < 5)
     deprecation (0.2.2)
       activesupport
-    devise (3.5.2)
+    devise (3.5.3)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 3.2.6, < 5)
@@ -181,7 +171,7 @@ GEM
     ffi (1.9.10)
     fission (0.5.0)
       CFPropertyList (~> 2.2)
-    fog (1.36.0)
+    fog (1.37.0)
       fog-aliyun (>= 0.1.0)
       fog-atmos
       fog-aws (>= 0.6.0)
@@ -203,10 +193,10 @@ GEM
       fog-terremark
       fog-vmfusion
       fog-voxel
+      fog-vsphere (>= 0.4.0)
       fog-xenserver
       fog-xml (~> 0.1.1)
       ipaddress (~> 0.5)
-      nokogiri (~> 1.5, >= 1.5.11)
     fog-aliyun (0.1.0)
       fog-core (~> 1.27)
       fog-json (~> 1.0)
@@ -260,7 +250,7 @@ GEM
       fog-core
       fog-json
       fog-xml
-    fog-sakuracloud (1.5.0)
+    fog-sakuracloud (1.7.5)
       fog-core
       fog-json
     fog-serverlove (0.1.2)
@@ -281,6 +271,9 @@ GEM
     fog-voxel (0.1.0)
       fog-core
       fog-xml
+    fog-vsphere (0.4.0)
+      fog-core
+      rbvmomi (~> 1.8)
     fog-xenserver (0.2.2)
       fog-core
       fog-xml
@@ -300,7 +293,7 @@ GEM
       activerecord (>= 4.2.0, < 4.3)
     haml (4.0.7)
       tilt
-    htmlcompressor (0.2.0)
+    htmlcompressor (0.3.0)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
     i18n (0.7.0)
@@ -330,17 +323,17 @@ GEM
       mime-types (>= 1.16, < 3)
     mime-types (2.99)
     mimemagic (0.3.0)
-    mini_portile (0.6.2)
+    mini_portile2 (2.0.0)
     minitest (5.8.3)
     multi_json (1.11.2)
     multipart-post (2.0.0)
     mustache (1.0.2)
     nested_form (0.3.2)
     netrc (0.11.0)
-    nokogiri (1.6.6.4)
-      mini_portile (~> 0.6.0)
+    nokogiri (1.6.7.1)
+      mini_portile2 (~> 2.0.0.rc2)
     orm_adapter (0.5.0)
-    paper_trail (4.0.0)
+    paper_trail (4.0.1)
       activerecord (>= 3.0, < 6.0)
       activesupport (>= 3.0, < 6.0)
       request_store (~> 1.1)
@@ -368,16 +361,16 @@ GEM
     rack-rewrite (1.5.1)
     rack-test (0.6.3)
       rack (>= 1.0)
-    rails (4.2.4)
-      actionmailer (= 4.2.4)
-      actionpack (= 4.2.4)
-      actionview (= 4.2.4)
-      activejob (= 4.2.4)
-      activemodel (= 4.2.4)
-      activerecord (= 4.2.4)
-      activesupport (= 4.2.4)
+    rails (4.2.5)
+      actionmailer (= 4.2.5)
+      actionpack (= 4.2.5)
+      actionview (= 4.2.5)
+      activejob (= 4.2.5)
+      activemodel (= 4.2.5)
+      activerecord (= 4.2.5)
+      activesupport (= 4.2.5)
       bundler (>= 1.3.0, < 2.0)
-      railties (= 4.2.4)
+      railties (= 4.2.5)
       sprockets-rails
     rails-deprecated_sanitizer (1.0.3)
       activesupport (>= 4.2.0.alpha)
@@ -390,7 +383,7 @@ GEM
     rails_12factor (0.0.3)
       rails_serve_static_assets
       rails_stdout_logging
-    rails_admin (0.7.0)
+    rails_admin (0.8.1)
       builder (~> 3.1)
       coffee-rails (~> 4.0)
       font-awesome-rails (>= 3.0, < 5)
@@ -404,16 +397,25 @@ GEM
       remotipart (~> 1.0)
       safe_yaml (~> 1.0)
       sass-rails (>= 4.0, < 6)
+    rails_admin_globalize_field (0.4.0)
+      globalize (>= 5.0)
+      rails (>= 4.2)
+      rails_admin (>= 0.6.2)
     rails_serve_static_assets (0.0.4)
     rails_stdout_logging (0.0.4)
-    railties (4.2.4)
-      actionpack (= 4.2.4)
-      activesupport (= 4.2.4)
+    railties (4.2.5)
+      actionpack (= 4.2.5)
+      activesupport (= 4.2.5)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rainbow (2.0.0)
     rake (10.4.2)
-    rdoc (4.2.0)
+    rbvmomi (1.8.2)
+      builder
+      nokogiri (>= 1.4.1)
+      trollop
+    rdoc (4.2.1)
+      json (~> 1.4)
     redis (3.2.2)
     redis-actionpack (4.0.1)
       actionpack (~> 4)
@@ -437,8 +439,8 @@ GEM
       redis (>= 2.2)
     remotipart (1.2.1)
     request_store (1.2.1)
-    responders (2.1.0)
-      railties (>= 4.2.0, < 5)
+    responders (2.1.1)
+      railties (>= 4.2.0, < 5.1)
     rest-client (1.8.0)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
@@ -471,7 +473,7 @@ GEM
     ruby-progressbar (1.7.5)
     rubyzip (1.1.7)
     safe_yaml (1.0.4)
-    sass (3.4.19)
+    sass (3.4.20)
     sass-rails (5.0.4)
       railties (>= 4.0.0, < 5.0)
       sass (~> 3.1)
@@ -498,10 +500,10 @@ GEM
     sprockets (3.5.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    sprockets-rails (2.3.3)
-      actionpack (>= 3.0)
-      activesupport (>= 3.0)
-      sprockets (>= 2.8, < 4.0)
+    sprockets-rails (3.0.0)
+      actionpack (>= 4.0)
+      activesupport (>= 4.0)
+      sprockets (>= 3.0.0)
     sweet_notifications (0.2.1)
       activesupport (>= 4.0, < 6)
       railties (>= 4.0, < 6)
@@ -512,6 +514,7 @@ GEM
     thread_safe (0.3.5)
     tilt (2.0.1)
     tins (1.6.0)
+    trollop (2.1.2)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uglifier (2.7.2)
@@ -520,7 +523,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.1)
-    warden (1.2.3)
+    warden (1.2.4)
       rack (>= 1.0)
     web-console (2.2.1)
       activemodel (>= 4.0)
@@ -551,7 +554,7 @@ DEPENDENCIES
   clockwork (~> 1.2)
   colorize
   coveralls
-  delayed_job_active_record (~> 4.0.3)
+  delayed_job_active_record (~> 4.1)
   devise (~> 3.5)
   dotenv-rails (~> 2.0)
   europeana-api (~> 0.4.2)
@@ -562,9 +565,9 @@ DEPENDENCIES
   foreman
   globalize (~> 5.0)
   globalize-versioning!
-  htmlcompressor (= 0.2)
+  htmlcompressor (= 0.3)
   localeapp (~> 0.9.0)
-  nokogiri (~> 1.6.6.4)
+  nokogiri (~> 1.6.7.1)
   paper_trail (~> 4.0)
   paperclip (~> 4.3)
   pg
@@ -572,10 +575,10 @@ DEPENDENCIES
   poltergeist
   puma (~> 2.13)
   rack-rewrite
-  rails (= 4.2.4)
+  rails (= 4.2.5)
   rails_12factor (~> 0.0.3)
-  rails_admin (~> 0.7.0)
-  rails_admin_globalize_field!
+  rails_admin (~> 0.8.0)
+  rails_admin_globalize_field (~> 0.4)
   redis-rails (~> 4.0)
   redis-rails-instrumentation
   rspec-rails (~> 3.0)


### PR DESCRIPTION
Including:
* Rails to version 4.2.5
* Nokogiri for security vulnerabilities