### PR TITLE
Re #628: fragment caching in Mustache templates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source 'https://rubygems.org'
 
 gem 'rails', '4.2.5'
 
+# NB: this *must* be by Git ref; else will break asset versioning in
+#     config/initializers/assets.rb, preventing app startup
 gem 'europeana-styleguide', github: 'europeana/europeana-styleguide-ruby', ref: '6f5971e'
 
 # Use a forked version of stache with downstream changes, until merged upstream

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,10 +17,6 @@ class ApplicationController < ActionController::Base
     super || User.new(guest: true)
   end
 
-  def cache_path_prefix
-    Rails.application.config.x.cache_version + '/'
-  end
-
   def default_url_options
     if ENV['HTTP_HOST']
       { host: ENV['HTTP_HOST'] }

--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -5,11 +5,9 @@ class BrowseController < ApplicationController
   include Europeana::Styleguide
 
   # GET /browse/colours
-  # @todo Get colours with a scheduled job and cache them
+  # @todo Load @colours from view helper, to bypass if HTML cached
   def colours
-    params = { query: '*:*', rows: 0, profile: 'minimal facets' }
-    response = repository.search(params)
-    @colours = response.aggregations['COLOURPALETTE'].items
+    @colours = Rails.cache.fetch('browse/colours/facets') || []
 
     respond_to do |format|
       format.html
@@ -17,7 +15,7 @@ class BrowseController < ApplicationController
   end
 
   # GET /browse/newcontent
-  # @todo Load @providers from view helper, to bypass if cached
+  # @todo Load @providers from view helper, to bypass if HTML cached
   def new_content
     @providers = Rails.cache.fetch('browse/new_content/providers') || []
 
@@ -27,7 +25,7 @@ class BrowseController < ApplicationController
   end
 
   # GET /browse/sources
-  # @todo Load @providers from view helper, to bypass if cached
+  # @todo Load @providers from view helper, to bypass if HTML cached
   def sources
     @providers = Rails.cache.fetch('browse/sources/providers') || []
     @providers.each do |provider|

--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -5,6 +5,7 @@ class BrowseController < ApplicationController
   include Europeana::Styleguide
 
   # GET /browse/colours
+  # @todo Get colours with a scheduled job and cache them
   def colours
     params = { query: '*:*', rows: 0, profile: 'minimal facets' }
     response = repository.search(params)
@@ -16,6 +17,7 @@ class BrowseController < ApplicationController
   end
 
   # GET /browse/newcontent
+  # @todo Load @providers from view helper, to bypass if cached
   def new_content
     @providers = Rails.cache.fetch('browse/new_content/providers') || []
 
@@ -25,6 +27,7 @@ class BrowseController < ApplicationController
   end
 
   # GET /browse/sources
+  # @todo Load @providers from view helper, to bypass if cached
   def sources
     @providers = Rails.cache.fetch('browse/sources/providers') || []
     @providers.each do |provider|

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -8,7 +8,7 @@ class HomeController < ApplicationController
   def index
     @collection = find_collection
     @landing_page = find_landing_page
-    @europeana_item_count = Rails.cache.fetch('record/counts/all') # populated by {RecordCountsCacheJob}
+    @europeana_item_count = Rails.cache.fetch('record/counts/all') # populated by {Cache::RecordCountsJob}
 
     respond_to do |format|
       format.html

--- a/app/jobs/cache/colour_facets_job.rb
+++ b/app/jobs/cache/colour_facets_job.rb
@@ -1,0 +1,13 @@
+class Cache::ColourFacetsJob < ActiveJob::Base
+  include ApiQueryingJob
+
+  queue_as :default
+
+  def perform
+    params = { query: '*:*', rows: 0, profile: 'minimal facets' }
+    response = repository.search(params)
+    colours = response.aggregations['COLOURPALETTE'].items
+    cache_key = 'browse/colours/facets'
+    Rails.cache.write(cache_key, colours)
+  end
+end

--- a/app/models/browse_entry.rb
+++ b/app/models/browse_entry.rb
@@ -1,8 +1,8 @@
 class BrowseEntry < ActiveRecord::Base
   include HasSettingsAttribute
 
-  belongs_to :page
-  belongs_to :media_object, dependent: :destroy
+  belongs_to :page, inverse_of: :browse_entries, touch: true
+  belongs_to :media_object, dependent: :destroy, inverse_of: :browse_entry
 
   has_settings(:category)
 

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -6,6 +6,8 @@ class Collection < ActiveRecord::Base
   validates :key, presence: true, uniqueness: true
   validates :api_params, presence: true
 
+  after_save :touch_landing_page
+
   def to_param
     key
   end
@@ -22,5 +24,9 @@ class Collection < ActiveRecord::Base
 
   def landing_page
     @landing_page ||= Page::Landing.find_by_slug("collections/#{key}")
+  end
+
+  def touch_landing_page
+    landing_page.touch if landing_page.present?
   end
 end

--- a/app/models/hero_image.rb
+++ b/app/models/hero_image.rb
@@ -5,13 +5,18 @@ class HeroImage < ActiveRecord::Base
                :attribution_url, :attribution_text, :brand_opacity, :brand_position,
                :brand_colour)
 
-  belongs_to :media_object, dependent: :destroy
+  has_one :page, inverse_of: :hero_image
+
+  belongs_to :media_object, dependent: :destroy, inverse_of: :hero_image
   accepts_nested_attributes_for :media_object, allow_destroy: true
 
   delegate :settings_brand_opacity_enum, :settings_brand_position_enum,
            :settings_brand_colour_enum, to: :class
 
   delegate :file, to: :media_object, allow_nil: true
+
+  after_save :touch_page
+  after_touch :touch_page
 
   has_paper_trail
 
@@ -38,4 +43,8 @@ class HeroImage < ActiveRecord::Base
   end
 
   validates :license, inclusion: { in: license_enum }, allow_nil: true
+
+  def touch_page
+    page.touch
+  end
 end

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -1,5 +1,5 @@
 class Link < ActiveRecord::Base
-  belongs_to :linkable, polymorphic: true
+  belongs_to :linkable, polymorphic: true, touch: true
 
   validates :url, presence: true
   validates :url, url: { allow_local: true }, allow_nil: true

--- a/app/models/link/promotion.rb
+++ b/app/models/link/promotion.rb
@@ -1,7 +1,7 @@
 class Link::Promotion < Link
   include HasSettingsAttribute
 
-  belongs_to :media_object, dependent: :destroy
+  belongs_to :media_object, dependent: :destroy, inverse_of: :promotion
   accepts_nested_attributes_for :media_object, allow_destroy: true
 
   has_settings(:wide, :category, :class)

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -1,8 +1,8 @@
 class Page < ActiveRecord::Base
   include HasPublicationStates
 
-  belongs_to :hero_image
-  has_many :browse_entries, -> { order(:position) }, dependent: :destroy
+  belongs_to :hero_image, inverse_of: :page
+  has_many :browse_entries, -> { order(:position) }, dependent: :destroy, inverse_of: :page
 
   accepts_nested_attributes_for :hero_image, allow_destroy: true
   accepts_nested_attributes_for :browse_entries, allow_destroy: true

--- a/app/views/application_view.rb
+++ b/app/views/application_view.rb
@@ -8,9 +8,28 @@
 class ApplicationView < Europeana::Styleguide::View
   include MustacheHelper
 
+  def cached_body
+    lambda do |text|
+      Rails.cache.fetch(cache_key, expires_in: 24.hours) do
+        render(text)
+      end
+    end
+  end
+
   protected
 
   def site_title
     'Europeana Collections'
+  end
+
+  private
+
+  def cache_key
+    'views/' + Rails.application.config.assets.version + '/' + I18n.locale.to_s + '/' + body_cache_key
+  end
+
+  # Implement this method in sub-classes to enable body caching
+  def body_cache_key
+    fail NotImplementedError
   end
 end

--- a/app/views/application_view.rb
+++ b/app/views/application_view.rb
@@ -10,7 +10,7 @@ class ApplicationView < Europeana::Styleguide::View
 
   def cached_body
     lambda do |text|
-      Rails.cache.fetch(cache_key, expires_in: 24.hours) do
+      Rails.cache.fetch(cache_key, expires_in: 24.hours, force: !cache_body?) do
         render(text)
       end
     end
@@ -31,5 +31,9 @@ class ApplicationView < Europeana::Styleguide::View
   # Implement this method in sub-classes to enable body caching
   def body_cache_key
     fail NotImplementedError
+  end
+
+  def cache_body?
+    !request.format.json?
   end
 end

--- a/app/views/browse/colours.html.mustache
+++ b/app/views/browse/colours.html.mustache
@@ -1,12 +1,13 @@
 {{>atoms/meta/_head}}
 
-{{> templates/Search/Search-colours}}
+{{#cached_body}}
+  {{> templates/Search/Search-colours}}
 
-{{# version.is_alpha }}
-{{> organisms/sections/phase-feedback }}
-{{/ version.is_alpha }}
+  {{# version.is_alpha }}
+    {{> organisms/sections/phase-feedback }}
+  {{/ version.is_alpha }}
 
-
-{{> organisms/global/footer }}
+  {{> organisms/global/footer }}
+{{/cached_body}}
 
 {{>atoms/meta/_foot}}

--- a/app/views/browse/colours.rb
+++ b/app/views/browse/colours.rb
@@ -33,5 +33,11 @@ module Browse
         ] + super
       end
     end
+
+    private
+
+    def body_cache_key
+      'browse/colours'
+    end
   end
 end

--- a/app/views/browse/new_content.html.mustache
+++ b/app/views/browse/new_content.html.mustache
@@ -1,13 +1,13 @@
 {{>atoms/meta/_head}}
 
+{{#cached_body}}
+  {{>templates/Search/Search-new-content }}
 
-{{>templates/Search/Search-new-content }}
+  {{# version.is_alpha }}
+    {{> organisms/sections/phase-feedback }}
+  {{/ version.is_alpha }}
 
-{{# version.is_alpha }}
-{{> organisms/sections/phase-feedback }}
-{{/ version.is_alpha }}
-
-
-{{> organisms/global/footer }}
+  {{> organisms/global/footer }}
+{{/cached_body}}
 
 {{>atoms/meta/_foot}}

--- a/app/views/browse/new_content.rb
+++ b/app/views/browse/new_content.rb
@@ -29,5 +29,11 @@ module Browse
         ] + super
       end
     end
+
+    private
+
+    def body_cache_key
+      'browse/newcontent'
+    end
   end
 end

--- a/app/views/browse/sources.html.mustache
+++ b/app/views/browse/sources.html.mustache
@@ -1,11 +1,13 @@
 {{>atoms/meta/_head}}
 
-{{> templates/Search/Search-sources}}
+{{#cached_body}}
+  {{> templates/Search/Search-sources}}
 
-{{# version.is_alpha }}
-{{> organisms/sections/phase-feedback }}
-{{/ version.is_alpha }}
+  {{# version.is_alpha }}
+    {{> organisms/sections/phase-feedback }}
+  {{/ version.is_alpha }}
 
-{{> organisms/global/footer }}
+  {{> organisms/global/footer }}
+{{/cached_body}}
 
 {{>atoms/meta/_foot}}

--- a/app/views/browse/sources.rb
+++ b/app/views/browse/sources.rb
@@ -60,5 +60,11 @@ module Browse
       end
       @providers
     end
+
+    private
+
+    def body_cache_key
+      'browse/sources'
+    end
   end
 end

--- a/app/views/collections/show.html.mustache
+++ b/app/views/collections/show.html.mustache
@@ -1,3 +1,5 @@
 {{>atoms/meta/_head}}
-{{>templates/Search/Channels-landing}}
+{{#cached_body}}
+  {{>templates/Search/Channels-landing}}
+{{/cached_body}}
 {{>atoms/meta/_foot}}

--- a/app/views/collections/show.rb
+++ b/app/views/collections/show.rb
@@ -63,6 +63,10 @@ module Collections
 
     private
 
+    def body_cache_key
+      @landing_page.cache_key
+    end
+
     def detect_link_in_array(links, domain)
       matcher = %r(://([^/]*.)?#{domain}/)
       links.detect { |l| l.url =~ matcher }

--- a/app/views/home/index.html.mustache
+++ b/app/views/home/index.html.mustache
@@ -1,3 +1,5 @@
 {{>atoms/meta/_head}}
-{{>templates/Search/Search-home}}
+{{#cached_body}}
+  {{>templates/Search/Search-home}}
+{{/cached_body}}
 {{>atoms/meta/_foot}}

--- a/app/views/home/index.rb
+++ b/app/views/home/index.rb
@@ -4,14 +4,6 @@ module Home
       'Europeana Collections'
     end
 
-    def cached_body
-      lambda do |text|
-        Rails.cache.fetch(cache_key, expires_in: 24.hours) do
-          render(text)
-        end
-      end
-    end
-
     def content
       mustache[:content] ||= begin
         {
@@ -39,8 +31,8 @@ module Home
 
     private
 
-    def cache_key
-      'views/' + Rails.application.config.assets.version + '/' + I18n.locale.to_s + '/' + @landing_page.cache_key
+    def body_cache_key
+      @landing_page.cache_key
     end
 
     def blog_news_items

--- a/app/views/home/index.rb
+++ b/app/views/home/index.rb
@@ -4,6 +4,14 @@ module Home
       'Europeana Collections'
     end
 
+    def cached_body
+      lambda do |text|
+        Rails.cache.fetch(cache_key, expires_in: 24.hours) do
+          render(text)
+        end
+      end
+    end
+
     def content
       mustache[:content] ||= begin
         {
@@ -30,6 +38,10 @@ module Home
     end
 
     private
+
+    def cache_key
+      'views/' + Rails.application.config.assets.version + '/' + I18n.locale.to_s + '/' + @landing_page.cache_key
+    end
 
     def blog_news_items
       @blog_news_items ||= news_items(feed_entries(Cache::FeedJob::URLS[:blog][:all]))

--- a/app/views/portal/static.html.mustache
+++ b/app/views/portal/static.html.mustache
@@ -1,3 +1,5 @@
 {{>atoms/meta/_head}}
-{{>templates/Search/Search-static-page}}
+{{#cached_body}}
+  {{>templates/Search/Search-static-page}}
+{{/cached_body}}
 {{>atoms/meta/_foot}}

--- a/app/views/portal/static.rb
+++ b/app/views/portal/static.rb
@@ -71,5 +71,11 @@ module Portal
         }
       ]
     end
+
+    private
+
+    def body_cache_key
+      @page.cache_key
+    end
   end
 end

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,7 +1,7 @@
 # Be sure to restart your server when you modify this file.
 
 # Version of your assets, change this if you want to expire all your assets.
-Rails.application.config.assets.version = Bundler.environment.dependencies.find { |d| d.name == 'europeana-styleguide' }.source.ref
+Rails.application.config.assets.version = Bundler.environment.dependencies.detect { |d| d.name == 'europeana-styleguide' }.source.ref
 
 # Add additional assets to the asset load path
 # Rails.application.config.assets.paths << Emoji.images_path

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,7 +1,7 @@
 # Be sure to restart your server when you modify this file.
 
 # Version of your assets, change this if you want to expire all your assets.
-Rails.application.config.assets.version = '1.0'
+Rails.application.config.assets.version = Bundler.environment.dependencies.find { |d| d.name == 'europeana-styleguide' }.source.ref
 
 # Add additional assets to the asset load path
 # Rails.application.config.assets.paths << Emoji.images_path

--- a/config/initializers/cache_version.rb
+++ b/config/initializers/cache_version.rb
@@ -1,1 +1,0 @@
-Rails.application.config.x.cache_version = '0.1'

--- a/lib/clock.rb
+++ b/lib/clock.rb
@@ -22,6 +22,7 @@ unless ENV['DISABLE_SCHEDULED_JOBS']
   end
 
   every(1.day, 'cache.record-counts', at: ENV['SCHEDULE_RECORD_COUNTS']) do
+    Cache::ColourFacetsJob.perform_later
     Cache::RecordCountsJob.perform_later
     Cache::RecordCounts::RecentAdditionsJob.perform_later
     Cache::RecordCounts::ProvidersJob.perform_later

--- a/spec/controllers/browse_controller_spec.rb
+++ b/spec/controllers/browse_controller_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe BrowseController do
   describe 'GET colours' do
     before(:each) do
+      Rails.cache.write('browse/colours/facets', [])
       get :colours
     end
 
@@ -9,8 +10,8 @@ RSpec.describe BrowseController do
       expect(response).to render_template('browse/colours')
     end
 
-    it 'should get colours from the API' do
-      expect(an_api_search_request).to have_been_made
+    it 'should not get colours from the API' do
+      expect(an_api_search_request).not_to have_been_made
     end
 
     it 'should assign colours from COLOURPALETTE facet' do


### PR DESCRIPTION
Uses lambdas to permit Russian-doll style fragment caching with cache keys based on object timestamps.