### PR TITLE
Re #851: semi-colons are not URL param delimiters

### DIFF
--- a/config/initializers/rack_rewrite.rb
+++ b/config/initializers/rack_rewrite.rb
@@ -7,7 +7,7 @@ Rails.application.configure do
     # @todo Move the logic into a class
     r301 %r{^/search.html\?},
       lambda { |_match, rack_env|
-        params = Rack::Utils.parse_query(rack_env['QUERY_STRING'])
+        params = Rack::Utils.parse_query(rack_env['QUERY_STRING'], '&')
 
         # Search query
         if params.key?('query')


### PR DESCRIPTION
`Rack::Utils.parse_query` treats them as such unless the delimiter
is passed explicitly.