### PR TITLE
Re #203: null session when missing CSRF params

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,7 @@ class ApplicationController < ActionController::Base
 
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
-  protect_from_forgery with: :exception
+  protect_from_forgery with: :null_session
 
   before_action :set_locale
 


### PR DESCRIPTION
In order to supply POST functionality when users have cookies disabled, use null session instead of exception for missing CSRF params.