### PR TITLE
Re #203: Skip verify_authenticity_token in Catalog

### DIFF
--- a/app/controllers/concerns/catalog.rb
+++ b/app/controllers/concerns/catalog.rb
@@ -14,6 +14,10 @@ module Catalog
   include ActiveSupport::Benchmarkable
   include CollectionsHelper
 
+  included do
+    skip_before_filter :verify_authenticity_token
+  end
+
   def doc_id
     @doc_id ||= '/' + params[:id]
   end

--- a/app/controllers/concerns/catalog.rb
+++ b/app/controllers/concerns/catalog.rb
@@ -15,7 +15,7 @@ module Catalog
   include CollectionsHelper
 
   included do
-    skip_before_filter :verify_authenticity_token
+    skip_before_action :verify_authenticity_token
   end
 
   def doc_id


### PR DESCRIPTION
When users have cookies disabled, POST requests will always fail, in order to prevent CSRF attacks. This is not a risk in the portal catalog scope where no data is written and no sensitive user data transmitted.