### PR TITLE
Re #869: page specific banners

### DIFF
--- a/app/helpers/mustache_helper.rb
+++ b/app/helpers/mustache_helper.rb
@@ -390,13 +390,17 @@ module MustacheHelper
 
   private
 
+  def page_banner(id = nil)
+    (id.nil? ? Banner.find_by_default(true) : Banner.find(id)).tap do |banner|
+      return nil unless (current_user || User.new(role: :guest)).can? :show, banner
+    end
+  end
+
   # @todo {User.new} does not belong here, but needed by request specs
   def banner_content(id = nil)
-    banner = id.nil? ? Banner.find_by_default(true) : Banner.find(id)
+    banner = page_banner(id)
 
-    return nil unless (current_user || User.new(role: :guest)).can? :show, banner
-
-    {
+    banner.nil? ? nil : {
       title: banner.title,
       text: banner.body,
       cta_url: banner.link.present? ? banner.link.url : nil,

--- a/app/helpers/mustache_helper.rb
+++ b/app/helpers/mustache_helper.rb
@@ -391,16 +391,17 @@ module MustacheHelper
   private
 
   def page_banner(id = nil)
-    banner = (id.nil? ? Banner.find_by_default(true) : Banner.find(id))
-    return nil unless (current_user || User.new(role: :guest)).can? :show, banner
-    banner
+    (id.nil? ? Banner.find_by_default(true) : Banner.find(id)).tap do |banner|
+      return nil unless (current_user || User.new(role: :guest)).can? :show, banner
+    end
   end
 
   # @todo {User.new} does not belong here, but needed by request specs
   def banner_content(id = nil)
     banner = page_banner(id)
+    return nil if banner.nil?
 
-    banner.nil? ? nil : {
+    {
       title: banner.title,
       text: banner.body,
       cta_url: banner.link.present? ? banner.link.url : nil,

--- a/app/helpers/mustache_helper.rb
+++ b/app/helpers/mustache_helper.rb
@@ -391,9 +391,9 @@ module MustacheHelper
   private
 
   def page_banner(id = nil)
-    (id.nil? ? Banner.find_by_default(true) : Banner.find(id)).tap do |banner|
-      return nil unless (current_user || User.new(role: :guest)).can? :show, banner
-    end
+    banner = (id.nil? ? Banner.find_by_default(true) : Banner.find(id))
+    return nil unless (current_user || User.new(role: :guest)).can? :show, banner
+    banner
   end
 
   # @todo {User.new} does not belong here, but needed by request specs

--- a/app/helpers/mustache_helper.rb
+++ b/app/helpers/mustache_helper.rb
@@ -380,23 +380,29 @@ module MustacheHelper
     end
   end
 
-  # @todo {User.new} does not belong here, but needed by request specs
   def content
     mustache[:content] ||= begin
-      banner = Banner.find_by_key('phase-feedback')
-      banner = Banner.new unless (current_user || User.new(role: :guest)).can? :show, banner
       {
-        phase_feedback: banner.new_record? ? nil : {
-          title: banner.title,
-          text: banner.body,
-          cta_url: banner.link.url,
-          cta_text: banner.link.text
-        }
+        phase_feedback: banner_content
       }
     end
   end
 
   private
+
+  # @todo {User.new} does not belong here, but needed by request specs
+  def banner_content(id = nil)
+    banner = id.nil? ? Banner.find_by_default(true) : Banner.find(id)
+
+    return nil unless (current_user || User.new(role: :guest)).can? :show, banner
+
+    {
+      title: banner.title,
+      text: banner.body,
+      cta_url: banner.link.present? ? banner.link.url : nil,
+      cta_text: banner.link.present? ? banner.link.text : nil
+    }
+  end
 
   def mustache
     @mustache ||= {}

--- a/app/models/banner.rb
+++ b/app/models/banner.rb
@@ -8,12 +8,12 @@ class Banner < ActiveRecord::Base
 
   delegate :url, :text, to: :link, prefix: true, allow_nil: true
 
-  before_save(if: :became_default?) do |banner|
+  before_save(if: :became_default?) do
     Banner.update_all(default: false)
   end
 
   validates :default, inclusion: { in: [false], message: 'has not been published' },
-    unless: :published?
+                      unless: :published?
 
   has_paper_trail
 

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -2,6 +2,7 @@ class Page < ActiveRecord::Base
   include HasPublicationStates
 
   belongs_to :hero_image, inverse_of: :page
+  belongs_to :banner, inverse_of: :pages
   has_many :browse_entries, -> { order(:position) }, dependent: :destroy, inverse_of: :page
 
   accepts_nested_attributes_for :hero_image, allow_destroy: true
@@ -15,6 +16,7 @@ class Page < ActiveRecord::Base
   accepts_nested_attributes_for :translations, allow_destroy: true
 
   validates :slug, uniqueness: true
+#   validates :banner, allow_nil: true
 
   scope :static, -> { where(type: nil) }
   scope :primary, -> { static.where('slug <> ? AND slug NOT LIKE ?', '', "%/%") }

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -16,7 +16,6 @@ class Page < ActiveRecord::Base
   accepts_nested_attributes_for :translations, allow_destroy: true
 
   validates :slug, uniqueness: true
-#   validates :banner, allow_nil: true
 
   scope :static, -> { where(type: nil) }
   scope :primary, -> { static.where('slug <> ? AND slug NOT LIKE ?', '', "%/%") }

--- a/app/views/application_view.rb
+++ b/app/views/application_view.rb
@@ -35,7 +35,6 @@ class ApplicationView < Europeana::Styleguide::View
   end
 
   def cache_key
-    
     'views/' + cache_version + '/' + I18n.locale.to_s + '/' + body_cache_key
   end
 

--- a/app/views/collections/show.rb
+++ b/app/views/collections/show.rb
@@ -56,7 +56,8 @@ module Collections
             items: blog_news_items,
             blogurl: 'http://blog.europeana.eu/tag/#' + @collection.key
           },
-          social: @landing_page.social_media.blank? ? nil : social_media_links
+          social: @landing_page.social_media.blank? ? nil : social_media_links,
+          phase_feedback: banner_content(@landing_page.banner_id)
         }.reverse_merge(helpers.content)
       end
     end

--- a/app/views/home/index.rb
+++ b/app/views/home/index.rb
@@ -13,7 +13,8 @@ module Home
           news: blog_news_items.blank? ? nil : {
             items: blog_news_items,
             blogurl: Cache::FeedJob::URLS[:blog][:all]
-          }
+          },
+          phase_feedback: banner_content(@landing_page.banner_id)
         }.reverse_merge(helpers.content)
       end
     end

--- a/app/views/pages/show.rb
+++ b/app/views/pages/show.rb
@@ -22,7 +22,8 @@ module Pages
           channel_entry: @page.browse_entries.blank? ? nil : {
             items: browse_entry_items(@page.browse_entries)
           },
-        }.merge(helpers.content)
+          phase_feedback: banner_content(@page.banner_id)
+        }.reverse_merge(helpers.content)
       end
     end
 

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -40,23 +40,25 @@ RailsAdmin.config do |config|
     visible true
     configure :translations, :globalize_tabs
     list do
-      field :key
       field :title
       field :state
+      field :default
     end
     show do
-      field :key
       field :title
       field :state
       field :body
+      field :default
       group :link do
         field :link_url
         field :link_text
       end
     end
     edit do
-      field :key
       field :translations
+      field :default do
+        help 'Only one, published, banner can be the default.'
+      end
       field :link
     end
   end
@@ -233,12 +235,14 @@ RailsAdmin.config do |config|
       field :body
       field :state
       field :browse_entries
+      field :banner
     end
     edit do
       field :slug
       field :translations
       field :hero_image
       field :browse_entries
+      field :banner
     end
   end
 
@@ -260,6 +264,7 @@ RailsAdmin.config do |config|
       field :body
       field :state
       field :browse_entries
+      field :banner
     end
     edit do
       field :slug
@@ -267,6 +272,7 @@ RailsAdmin.config do |config|
       field :translations
       field :hero_image
       field :browse_entries
+      field :banner
     end
   end
 
@@ -288,6 +294,7 @@ RailsAdmin.config do |config|
       field :social_media
       field :promotions
       field :browse_entries
+      field :banner
     end
     edit do
       field :slug
@@ -297,6 +304,7 @@ RailsAdmin.config do |config|
       field :social_media
       field :promotions
       field :browse_entries
+      field :banner
     end
   end
 

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -2,7 +2,7 @@ require 'rails_admin/config/actions/publish'
 require 'rails_admin/config/actions/unpublish'
 
 RailsAdmin.config do |config|
-  config.main_app_name = ["Europeana Collections"]
+  config.main_app_name = ['Europeana Collections']
 
   # Devise
   config.authenticate_with do

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -2,6 +2,8 @@ require 'rails_admin/config/actions/publish'
 require 'rails_admin/config/actions/unpublish'
 
 RailsAdmin.config do |config|
+  config.main_app_name = ["Europeana Collections"]
+
   # Devise
   config.authenticate_with do
     warden.authenticate! scope: :user

--- a/db/migrate/20160119090126_add_banner_id_to_pages.rb
+++ b/db/migrate/20160119090126_add_banner_id_to_pages.rb
@@ -1,0 +1,7 @@
+class AddBannerIdToPages < ActiveRecord::Migration
+  def change
+    add_column :pages, :banner_id, :integer
+    add_index :pages, :banner_id
+    add_foreign_key :pages, :banners
+  end
+end

--- a/db/migrate/20160119093141_add_default_to_banners.rb
+++ b/db/migrate/20160119093141_add_default_to_banners.rb
@@ -1,0 +1,10 @@
+class AddDefaultToBanners < ActiveRecord::Migration
+  class Banner < ActiveRecord::Base; end
+
+  def change
+    add_column :banners, :default, :boolean, default: false
+    add_index :banners, :default
+
+    Banner.find_by_key('phase-feedback').update_attributes(default: true)
+  end
+end

--- a/db/migrate/20160119093503_remove_key_from_banners.rb
+++ b/db/migrate/20160119093503_remove_key_from_banners.rb
@@ -1,0 +1,5 @@
+class RemoveKeyFromBanners < ActiveRecord::Migration
+  def change
+    remove_column :banners, :key, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151028103631) do
+ActiveRecord::Schema.define(version: 20160119093503) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -29,13 +29,13 @@ ActiveRecord::Schema.define(version: 20151028103631) do
   add_index "banner_translations", ["locale"], name: "index_banner_translations_on_locale", using: :btree
 
   create_table "banners", force: :cascade do |t|
-    t.string   "key",        limit: 255
-    t.datetime "created_at",                         null: false
-    t.datetime "updated_at",                         null: false
-    t.integer  "state",                  default: 0
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
+    t.integer  "state",      default: 0
+    t.boolean  "default",    default: false
   end
 
-  add_index "banners", ["key"], name: "index_banners_on_key", using: :btree
+  add_index "banners", ["default"], name: "index_banners_on_default", using: :btree
 
   create_table "bookmarks", force: :cascade do |t|
     t.integer  "user_id",                   null: false
@@ -167,8 +167,10 @@ ActiveRecord::Schema.define(version: 20151028103631) do
     t.integer  "http_code"
     t.datetime "created_at",                            null: false
     t.datetime "updated_at",                            null: false
+    t.integer  "banner_id"
   end
 
+  add_index "pages", ["banner_id"], name: "index_pages_on_banner_id", using: :btree
   add_index "pages", ["hero_image_id"], name: "index_pages_on_hero_image_id", using: :btree
   add_index "pages", ["http_code"], name: "index_pages_on_http_code", using: :btree
   add_index "pages", ["slug"], name: "index_pages_on_slug", using: :btree
@@ -227,4 +229,5 @@ ActiveRecord::Schema.define(version: 20151028103631) do
   add_index "versions", ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id", using: :btree
   add_index "versions", ["transaction_id"], name: "index_versions_on_transaction_id", using: :btree
 
+  add_foreign_key "pages", "banners"
 end

--- a/db/seeds/banners.rb
+++ b/db/seeds/banners.rb
@@ -1,13 +1,13 @@
-unless Banner.find_by_key('phase-feedback').present?
+unless Banner.find_by_default(true).present?
   ActiveRecord::Base.transaction do
     Banner.create!(
-      key: 'phase-feedback',
       title: 'This is an Alpha release of our new collections search and Music Collection',
       body: 'An Alpha release means that this website is in active development and will be updated regularly. It may sometimes be offline. Your feedback will help us improve our site.',
       link: Link.new(
         url: 'http://insights.hotjar.com/s?siteId=54631&surveyId=2939',
         text: 'Give us your input!'
-      )
+      ),
+      default: true
     ).publish!
   end
 end

--- a/spec/fixtures/banner/translations.yml
+++ b/spec/fixtures/banner/translations.yml
@@ -1,5 +1,5 @@
-generic_banner_translations:
+default_banner_translations:
   locale: en
   title: Banner title
   body: Banner body
-  globalized_model: generic_banner
+  globalized_model: default_banner

--- a/spec/fixtures/banners.yml
+++ b/spec/fixtures/banners.yml
@@ -1,7 +1,6 @@
-generic_banner:
-  key: generic
+default_banner:
+  default: true
   state: 1
 
 draft_banner:
-  key: draft
   state: 0

--- a/spec/fixtures/links.yml
+++ b/spec/fixtures/links.yml
@@ -1,3 +1,3 @@
-generic_banner_link:
+default_banner_link:
   url: 'http://www.example.com/'
-  linkable: generic_banner (Banner)
+  linkable: default_banner (Banner)

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Ability do
   end
 
   let(:draft_banner) { banners(:draft_banner) }
-  let(:published_banner) { banners(:generic_banner) }
+  let(:published_banner) { banners(:default_banner) }
   let(:draft_collection) { collections(:draft) }
   let(:published_collection) { collections(:music) }
   let(:draft_landing_page) { pages(:draft_landing_page) }

--- a/spec/models/banner_spec.rb
+++ b/spec/models/banner_spec.rb
@@ -1,7 +1,32 @@
 RSpec.describe Banner do
-  it { is_expected.to have_one(:link) }
-  it { is_expected.to validate_uniqueness_of(:key).allow_nil }
+  it { is_expected.to have_one(:link).dependent(:destroy) }
+  it { is_expected.to have_many(:pages).dependent(:nullify).inverse_of(:banner) }
   it { is_expected.to accept_nested_attributes_for(:link) }
   it { is_expected.to delegate_method(:url).to(:link).with_prefix(true) }
   it { is_expected.to delegate_method(:text).to(:link).with_prefix(true) }
+
+  it 'can only be made default if it is published' do
+    draft = banners(:draft_banner)
+    draft.default = true
+    expect(draft).not_to be_valid
+    draft.publish!
+    expect(draft).to be_valid
+  end
+
+  it 'should only permit one to be default' do
+    expect(Banner.where(default: true).count).to eq(1)
+    default_id_was = Banner.find_by_default(true).id
+
+    new_default = Banner.new
+    new_default.save
+    new_default.publish!
+    new_default.default = true
+    new_default.save
+    expect(new_default).to be_valid
+
+    expect(Banner.where(default: true).count).to eq(1)
+    default_id_is = Banner.find_by_default(true).id
+    expect(default_id_is).not_to eq(default_id_was)
+    expect(default_id_is).to eq(new_default.id)
+  end
 end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe Page do
-  it { is_expected.to belong_to(:hero_image) }
+  it { is_expected.to belong_to(:banner).inverse_of(:pages) }
+  it { is_expected.to belong_to(:hero_image).inverse_of(:page) }
   it { is_expected.to validate_uniqueness_of(:slug) }
 
   it { is_expected.to accept_nested_attributes_for(:hero_image) }


### PR DESCRIPTION
* associate `Page` with `Banner` model
* add `default` boolean attribute to `Banner`
* remove `key` string attribute from `Banner`
* max one `Banner` can have `default == true`
* default banner is shown on all pages without an explicit banner associated