### PR TITLE
Translate content in CMS via language select

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'rails', '4.2.5.2'
 
 # NB: this *must* be by Git ref; else will break asset versioning in
 #     config/initializers/assets.rb, preventing app startup
-gem 'europeana-styleguide', github: 'europeana/europeana-styleguide-ruby', ref: 'a386cb1'
+gem 'europeana-styleguide', github: 'europeana/europeana-styleguide-ruby', ref: 'ab30cfa'
 
 # Use a forked version of stache with downstream changes, until merged upstream
 # @see https://github.com/agoragames/stache/pulls/rwd
@@ -33,10 +33,8 @@ gem 'paper_trail', '~> 4.0'
 gem 'puma', '~> 2.13'
 gem 'rack-rewrite'
 gem 'rails_admin', '~> 0.8.0'
-gem 'rails_admin_globalize_field', '~> 0.4'
 gem 'redis-rails', '~> 4.0'
 gem 'redis-rails-instrumentation'
-gem 'responders', '~> 2.1'
 gem 'sass-rails'
 gem 'soundcloud', '~> 0.3'
 gem 'therubyracer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: git://github.com/europeana/europeana-styleguide-ruby.git
-  revision: a386cb1127370a09939a01e1daae7550714175bf
-  ref: a386cb1
+  revision: ab30cfa3b03002f47de02d834e4788e693e10e03
+  ref: ab30cfa
   specs:
     europeana-styleguide (0.1.0)
       activesupport (~> 4.0)
@@ -406,10 +406,6 @@ GEM
       remotipart (~> 1.0)
       safe_yaml (~> 1.0)
       sass-rails (>= 4.0, < 6)
-    rails_admin_globalize_field (0.4.0)
-      globalize (>= 5.0)
-      rails (>= 4.2)
-      rails_admin (>= 0.6.2)
     rails_serve_static_assets (0.0.4)
     rails_stdout_logging (0.0.4)
     railties (4.2.5.2)
@@ -600,10 +596,8 @@ DEPENDENCIES
   rails (= 4.2.5.2)
   rails_12factor (~> 0.0.3)
   rails_admin (~> 0.8.0)
-  rails_admin_globalize_field (~> 0.4)
   redis-rails (~> 4.0)
   redis-rails-instrumentation
-  responders (~> 2.1)
   rspec-rails (~> 3.0)
   rubocop (= 0.35.1)
   ruby-oembed (~> 0.9)

--- a/app/assets/stylesheets/rails_admin/custom/theming.scss
+++ b/app/assets/stylesheets/rails_admin/custom/theming.scss
@@ -1,0 +1,3 @@
+.navbar-nav > li > form {
+  padding: 15px;
+}

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -16,8 +16,8 @@ class SettingsController < ApplicationController
 
     respond_to do |format|
       format.html do
-        if params[:redirect] && params[:redirect] =~ %r{\A/}
-          redirect_to params[:redirect]
+        if local_redirect
+          redirect_to local_redirect
         else
           render action: :language, status: flash_status
         end
@@ -30,6 +30,16 @@ class SettingsController < ApplicationController
   end
 
   protected
+
+  def local_redirect
+    @local_redirect ||= begin
+      if params[:redirect] && params[:redirect].is_a?(String) && params[:redirect] =~ %r{\A/}
+        params[:redirect]
+      else
+        nil
+      end
+    end
+  end
 
   def flash_status
     flash.key?(:alert) ? 400 : 200

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -16,7 +16,7 @@ class SettingsController < ApplicationController
 
     respond_to do |format|
       format.html do
-        if params[:redirect]
+        if params[:redirect] && params[:redirect] =~ %r{\A/}
           redirect_to params[:redirect]
         else
           render action: :language, status: flash_status

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -15,7 +15,13 @@ class SettingsController < ApplicationController
     locales = set_locale_from_param
 
     respond_to do |format|
-      format.html { render action: :language, status: flash_status }
+      format.html do
+        if params[:redirect]
+          redirect_to params[:redirect]
+        else
+          render action: :language, status: flash_status
+        end
+      end
       format.json do
         render json: flash_json.merge(refresh: (locales.first != locales.last)),
                status: flash_status

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -31,12 +31,12 @@ class SettingsController < ApplicationController
 
   protected
 
+  ##
+  # Ensure that only local paths are accepted as redirect targets
   def local_redirect
     @local_redirect ||= begin
       if params[:redirect] && params[:redirect].is_a?(String) && params[:redirect] =~ %r{\A/}
         params[:redirect]
-      else
-        nil
       end
     end
   end

--- a/app/helpers/i18n_helper.rb
+++ b/app/helpers/i18n_helper.rb
@@ -1,0 +1,33 @@
+module I18nHelper
+  def language_map
+    {
+      bg: 'bulgarian',
+      ca: 'catalan',
+      da: 'danish',
+      de: 'german',
+      el: 'greek',
+      en: 'english',
+      es: 'spanish',
+      # et: 'estonian',
+      fi: 'finnish',
+      fr: 'french',
+      hr: 'croatian',
+      hu: 'hungarian',
+      it: 'italian',
+      lt: 'lithuanian',
+      lv: 'latvian',
+      nl: 'dutch',
+      pl: 'polish',
+      pt: 'portuguese',
+      ro: 'romanian',
+      ru: 'russian',
+      sv: 'swedish'
+    }
+  end
+
+  def language_options_for_select
+    localised = language_map.map { |k, v| [t("global.language-#{v}"), k.to_s] }
+    localised.sort_by! { |v| v.first }
+    options_for_select(localised, I18n.locale.to_s)
+  end
+end

--- a/app/helpers/i18n_helper.rb
+++ b/app/helpers/i18n_helper.rb
@@ -27,7 +27,7 @@ module I18nHelper
 
   def language_options_for_select
     localised = language_map.map { |k, v| [t("global.language-#{v}"), k.to_s] }
-    localised.sort_by! { |v| v.first }
+    localised.sort_by!(&:first)
     options_for_select(localised, I18n.locale.to_s)
   end
 end

--- a/app/views/layouts/rails_admin/_language_select.html.erb
+++ b/app/views/layouts/rails_admin/_language_select.html.erb
@@ -1,0 +1,5 @@
+<%= form_tag(main_app.settings_language_path, method: :put) do %>
+  <%= select_tag('locale', language_options_for_select, title: t('site.settings.language.label')) %>
+  <%= hidden_field_tag('redirect', request.fullpath) %>
+  <%= submit_tag('Go') %>
+<% end %>

--- a/app/views/layouts/rails_admin/_secondary_navigation.html.haml
+++ b/app/views/layouts/rails_admin/_secondary_navigation.html.haml
@@ -1,0 +1,11 @@
+%ul.nav.navbar-nav.navbar-right.root_links
+  %li= render partial: 'layouts/rails_admin/language_select'
+  - actions(:root).each do |action|
+    %li{class: "#{action.action_name}_root_link"}= link_to wording_for(:menu, action), { action: action.action_name, controller: 'rails_admin/main' }, class: "pjax"
+  - if main_app_root_path = (main_app.root_path rescue false)
+    %li= link_to t('admin.home.name'), main_app_root_path
+  - if _current_user
+    - if user_link = edit_user_link
+      %li.edit_user_root_link= user_link
+    - if logout_path.present?
+      %li= link_to content_tag('span', t('admin.misc.log_out'), class: 'label label-danger'), logout_path, method: logout_method

--- a/app/views/settings/language.rb
+++ b/app/views/settings/language.rb
@@ -68,32 +68,6 @@ module Settings
 
     protected
 
-    def language_map
-      {
-        bg: 'bulgarian',
-        ca: 'catalan',
-        da: 'danish',
-        de: 'german',
-        el: 'greek',
-        en: 'english',
-        es: 'spanish',
-        # et: 'estonian',
-        fi: 'finnish',
-        fr: 'french',
-        hr: 'croatian',
-        hu: 'hungarian',
-        it: 'italian',
-        lt: 'lithuanian',
-        lv: 'latvian',
-        nl: 'dutch',
-        pl: 'polish',
-        pt: 'portuguese',
-        ro: 'romanian',
-        ru: 'russian',
-        sv: 'swedish'
-      }
-    end
-
     def language_item(k, v)
       {
         text: t("global.language-#{v}"),

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -17,9 +17,8 @@ RailsAdmin.config do |config|
   config.audit_with :paper_trail, 'User', 'PaperTrail::Version'
 
   config.included_models = %w(
-    Banner Banner::Translation BrowseEntry BrowseEntry::Translation Collection HeroImage
-    Link Link::Translation Link::Promotion Link::Credit Link::SocialMedia MediaObject Page
-    Page::Error Page::Landing Page::Translation User
+    Banner BrowseEntry Collection HeroImage Link Link::Promotion Link::Credit
+    Link::SocialMedia MediaObject Page Page::Error Page::Landing User
   )
 
   config.actions do
@@ -39,8 +38,6 @@ RailsAdmin.config do |config|
   end
 
   config.model 'Banner' do
-    visible true
-    configure :translations, :globalize_tabs
     list do
       field :title
       field :state
@@ -57,7 +54,8 @@ RailsAdmin.config do |config|
       end
     end
     edit do
-      field :translations
+      field :title
+      field :body
       field :default do
         help 'Only one, published, banner can be the default.'
       end
@@ -65,16 +63,7 @@ RailsAdmin.config do |config|
     end
   end
 
-  config.model 'Banner::Translation' do
-    visible false
-    configure :locale, :hidden do
-      help ''
-    end
-    include_fields :locale, :title, :body
-  end
-
   config.model 'BrowseEntry' do
-    configure :translations, :globalize_tabs
     list do
       field :title
       field :file, :paperclip
@@ -93,7 +82,7 @@ RailsAdmin.config do |config|
       field :collections
     end
     edit do
-      field :translations
+      field :title
       field :query
       field :file, :paperclip
       field :subject_type
@@ -102,14 +91,6 @@ RailsAdmin.config do |config|
         inline_add false
       end
     end
-  end
-
-  config.model 'BrowseEntry::Translation' do
-    visible false
-    configure :locale, :hidden do
-      help ''
-    end
-    include_fields :locale, :title
   end
 
   config.model 'Collection' do
@@ -183,28 +164,18 @@ RailsAdmin.config do |config|
   config.model 'Link' do
     object_label_method :text
     visible false
-    configure :translations, :globalize_tabs
     edit do
       field :url, :string
-      field :translations
+      field :text
     end
-  end
-
-  config.model 'Link::Translation' do
-    visible false
-    configure :locale, :hidden do
-      help ''
-    end
-    include_fields :locale, :text
   end
 
   config.model 'Link::Promotion' do
     object_label_method :text
     visible false
-    configure :translations, :globalize_tabs
     edit do
       field :url, :string
-      field :translations
+      field :text
       field :position do
         help 'Items with lower positions appear first.'
       end
@@ -218,20 +189,18 @@ RailsAdmin.config do |config|
   config.model 'Link::SocialMedia' do
     object_label_method :text
     visible false
-    configure :translations, :globalize_tabs
     edit do
       field :url, :string
-      field :translations
+      field :text
     end
   end
 
   config.model 'Link::Credit' do
     object_label_method :text
     visible false
-    configure :translations, :globalize_tabs
     edit do
       field :url, :string
-      field :translations
+      field :text
     end
   end
 
@@ -244,7 +213,6 @@ RailsAdmin.config do |config|
 
   config.model 'Page' do
     object_label_method :title
-    configure :translations, :globalize_tabs
     list do
       field :slug
       field :title
@@ -263,7 +231,10 @@ RailsAdmin.config do |config|
     end
     edit do
       field :slug
-      field :translations
+      field :title
+      field :body, :text do
+        html_attributes rows: 15, cols: 80
+      end
       field :hero_image
       field :browse_entries do
         orderable true
@@ -276,7 +247,6 @@ RailsAdmin.config do |config|
 
   config.model 'Page::Error' do
     object_label_method :title
-    configure :translations, :globalize_tabs
     list do
       field :slug
       field :http_code
@@ -297,7 +267,10 @@ RailsAdmin.config do |config|
     edit do
       field :slug
       field :http_code
-      field :translations
+      field :title
+      field :body, :text do
+        html_attributes rows: 15, cols: 80
+      end
       field :hero_image
       field :browse_entries do
         orderable true
@@ -309,7 +282,6 @@ RailsAdmin.config do |config|
 
   config.model 'Page::Landing' do
     object_label_method :title
-    configure :translations, :globalize_tabs
     list do
       field :slug
       field :title
@@ -329,7 +301,10 @@ RailsAdmin.config do |config|
     end
     edit do
       field :slug
-      field :translations
+      field :title
+      field :body, :text do
+        html_attributes rows: 15, cols: 80
+      end
       field :hero_image
       field :credits
       field :social_media
@@ -343,20 +318,6 @@ RailsAdmin.config do |config|
         end
       end
       field :banner
-    end
-  end
-
-  config.model 'Page::Translation' do
-    visible false
-    configure :locale, :hidden do
-      help ''
-    end
-    include_fields :locale, :title, :body
-    edit do
-      field :title
-      field :body, :text do
-        html_attributes rows: 15, cols: 80
-      end
     end
   end
 

--- a/spec/config/initializers/rails_admin_spec.rb
+++ b/spec/config/initializers/rails_admin_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe RailsAdmin.config do
   describe '#included_models' do
     subject { RailsAdmin.config.included_models }
-    it { is_expected.to eq(%w(Banner Banner::Translation BrowseEntry BrowseEntry::Translation Collection HeroImage Link Link::Translation Link::Promotion Link::Credit Link::SocialMedia MediaObject Page Page::Error Page::Landing Page::Translation User)) }
+    it { is_expected.to eq(%w(Banner BrowseEntry Collection HeroImage Link Link::Promotion Link::Credit Link::SocialMedia MediaObject Page Page::Error Page::Landing User)) }
   end
 
   describe '#model' do

--- a/spec/config/initializers/rails_admin_spec.rb
+++ b/spec/config/initializers/rails_admin_spec.rb
@@ -1,7 +1,9 @@
 RSpec.describe RailsAdmin.config do
   describe '#included_models' do
     subject { RailsAdmin.config.included_models }
-    it { is_expected.to eq(%w(Banner BrowseEntry Collection HeroImage Link Link::Promotion Link::Credit Link::SocialMedia MediaObject Page Page::Error Page::Landing User)) }
+    it { is_expected.to eq(%w(Banner BrowseEntry Collection HeroImage Link
+                              Link::Promotion Link::Credit Link::SocialMedia
+                              MediaObject Page Page::Error Page::Landing User)) }
   end
 
   describe '#model' do

--- a/spec/config/initializers/rails_admin_spec.rb
+++ b/spec/config/initializers/rails_admin_spec.rb
@@ -1,9 +1,7 @@
 RSpec.describe RailsAdmin.config do
   describe '#included_models' do
     subject { RailsAdmin.config.included_models }
-    it { is_expected.to eq(%w(Banner BrowseEntry Collection HeroImage Link
-                              Link::Promotion Link::Credit Link::SocialMedia
-                              MediaObject Page Page::Error Page::Landing User)) }
+    it { is_expected.to eq(%w(Banner BrowseEntry Collection HeroImage Link Link::Promotion Link::Credit Link::SocialMedia MediaObject Page Page::Error Page::Landing User)) }
   end
 
   describe '#model' do


### PR DESCRIPTION
In order to improve performance of CMS where there are many translatable content elements, and many languages, resulting in huge forms.