### PR TITLE
Fix country canned search

### DIFF
--- a/app/views/portal/show.rb
+++ b/app/views/portal/show.rb
@@ -283,7 +283,8 @@ module Portal
                   title: 'site.object.meta-label.providing-country',
                   fields: ['europeanaAggregation.edmCountry'],
                   search_field: 'COUNTRY',
-                  ga_data: 'dimension2'
+                  ga_data: 'dimension2',
+                  quoted: true
                 },
                 {
                   title: 'site.object.meta-label.timestamp-created',


### PR DESCRIPTION
By enclosing the search terms in quotes, not parentheses