### PR TITLE
Only format dates with "-" after the first char

### DIFF
--- a/app/views/portal/show.rb
+++ b/app/views/portal/show.rb
@@ -839,7 +839,7 @@ module Portal
     end
 
     def format_date(text, format)
-      return text if format.nil?
+      return text if format.nil? || (text !=~ /^.+-/)
       Time.parse(text).strftime(format)
     rescue ArgumentError
       text

--- a/app/views/portal/show.rb
+++ b/app/views/portal/show.rb
@@ -839,7 +839,7 @@ module Portal
     end
 
     def format_date(text, format)
-      return text if format.nil? || (text !=~ /^.+-/)
+      return text if format.nil? || (text ! =~ /^.+-/)
       Time.parse(text).strftime(format)
     rescue ArgumentError
       text

--- a/app/views/portal/show.rb
+++ b/app/views/portal/show.rb
@@ -839,7 +839,7 @@ module Portal
     end
 
     def format_date(text, format)
-      return text if format.nil? || (text ! =~ /^.+-/)
+      return text if format.nil? || (text !=~ /^.+-/)
       Time.parse(text).strftime(format)
     rescue ArgumentError
       text


### PR DESCRIPTION
To avoid Ruby's time parser, e.g., interpretting "-0322" (322 BC) as something else.