### PR TITLE
Revert "Do not send error report emails"

### DIFF
--- a/app/controllers/concerns/controller_exception_handling.rb
+++ b/app/controllers/concerns/controller_exception_handling.rb
@@ -63,6 +63,15 @@ module ControllerExceptionHandling
     logger.error("#{message}\n".red.bold)
   end
 
+  def report_error(exception)
+    return unless Rails.application.config.x.error_report_mail_to.present? # No email recipient configured
+
+    ErrorMailer.report_http(
+      { class: exception.class.to_s, message: exception.message, backtrace: exception.backtrace },
+      { original_url: request.original_url, method: request.method, referer: request.referer }
+    ).deliver_later
+  end
+
   def render_html_error_response(exception, status)
     @page = Page::Error.for_exception(exception, status)
     @page ||= Page::Error.generic.find_by_http_code!(status)

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -2,4 +2,15 @@
 # Base class job background jobs
 class ApplicationJob < ActiveJob::Base
   include ActiveSupport::Benchmarkable
+
+  rescue_from(StandardError) do |exception|
+    return unless Rails.application.config.x.error_report_mail_to.present? # No email recipient configured
+
+    ErrorMailer.report_job(
+      { class: exception.class.to_s, message: exception.message, backtrace: exception.backtrace },
+      { class: self.class.to_s, arguments: arguments.inspect }
+    ).deliver_later
+
+    raise exception
+  end
 end


### PR DESCRIPTION
Reverts europeana/europeana-portal-collections#512

We should retain the _option_ to send error report emails. In specific environments it can just be disabled by not setting the `ERROR_REPORT_MAIL_TO` env var.