### PR TITLE
Generate stats when a collection is published

### DIFF
--- a/app/jobs/cache/record_counts_job.rb
+++ b/app/jobs/cache/record_counts_job.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Cache
   class RecordCountsJob < ApplicationJob
     include ApiQueryingJob
@@ -5,27 +6,29 @@ module Cache
 
     queue_as :default
 
-    def perform(collection_id = nil, options = {})
-      api_query = search_builder.rows(0).merge(query: '*:*', profile: 'minimal')
+    def perform(collection_id = nil, **options)
+      collection = Collection.find_by_id(collection_id)
 
-      collection = nil
-      unless collection_id.nil?
-        collection = Collection.find(collection_id)
-        unless collection.nil?
-          api_query.with_overlay_params(collection.api_params_hash)
-        end
-      end
-
-      cache_key = record_count_cache_key(collection: collection)
-      cache_query_count(api_query, cache_key)
+      perform_for(collection: collection)
 
       if options[:types]
-        EDM::Type.registry.each do |type|
-          type_cache_key = record_count_cache_key(collection: collection, type: type)
-          type_api_query = api_query.merge(query: "TYPE:#{type.id}")
-          cache_query_count(type_api_query, type_cache_key)
-        end
+        EDM::Type.registry.each { |type| perform_for(collection: collection, type: type) }
       end
+
+      collection.touch_landing_page unless collection.nil? # Expire landing page cache to show new counts
+    end
+
+    protected
+
+    def perform_for(**args)
+      cache_query_count(api_query(**args), record_count_cache_key(**args))
+    end
+
+    def api_query(collection: nil, type: nil)
+      query = search_builder.rows(0).merge(query: '*:*', profile: 'minimal')
+      query.with_overlay_params(collection.api_params_hash) unless collection.nil?
+      query = query.merge(query: "TYPE:#{type.id}") unless type.nil?
+      query
     end
   end
 end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -46,4 +46,12 @@ class Collection < ActiveRecord::Base
   def touch_landing_page
     landing_page.touch if landing_page.present?
   end
+
+  def after_publish
+    trigger_record_counts_job
+  end
+
+  def trigger_record_counts_job
+    Cache::RecordCountsJob.perform_later(id, types: true)
+  end
 end

--- a/app/models/concerns/has_publication_states.rb
+++ b/app/models/concerns/has_publication_states.rb
@@ -10,7 +10,7 @@ module HasPublicationStates
       state :draft, initial: true
       state :published
 
-      event :publish do
+      event :publish, after: :after_publish do
         transitions from: :draft, to: :published
       end
 
@@ -18,5 +18,10 @@ module HasPublicationStates
         transitions from: :published, to: :draft
       end
     end
+  end
+
+  ##
+  # Override this per-model if required
+  def after_publish
   end
 end

--- a/spec/jobs/cache/record_counts_job_spec.rb
+++ b/spec/jobs/cache/record_counts_job_spec.rb
@@ -27,6 +27,10 @@ RSpec.describe Cache::RecordCountsJob do
     let(:api_request) { an_api_collection_search_request(collection.id) }
 
     it_behaves_like 'record count caching job'
+
+    it 'should touch the landing page' do
+      expect { subject.perform(*args) }.to change { collection.landing_page.reload.updated_at }
+    end
   end
 
   context 'with `types` option = true' do

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -11,4 +11,11 @@ RSpec.describe Collection do
       it { is_expected.to eq(collection.key) }
     end
   end
+
+  describe '#publish' do
+    subject { collections(:draft).publish }
+    it 'should enqueue a record counts job' do
+      expect { subject }.to change { Delayed::Job.where("handler LIKE '%Cache::RecordCountsJob%'").count }.by(1)
+    end
+  end
 end


### PR DESCRIPTION
* Job enqueued to retrieve the record count stats
* Job touches collection landing page on completion, to expire its cached HTML and display stats immediately