### PR TITLE
Per-collection default search layout setting

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
 class Collection < ActiveRecord::Base
   include HasPublicationStates
+  include HasSettingsAttribute
 
   has_and_belongs_to_many :browse_entries
 
@@ -13,6 +15,16 @@ class Collection < ActiveRecord::Base
   translates :title, fallbacks_for_empty_translations: true
   accepts_nested_attributes_for :translations, allow_destroy: true
   default_scope { includes(:translations) }
+
+  has_settings :default_search_layout
+
+  delegate :settings_default_search_layout_enum, to: :class
+
+  class << self
+    def settings_default_search_layout_enum
+      %w(list grid)
+    end
+  end
 
   def to_param
     key

--- a/app/views/portal/index.rb
+++ b/app/views/portal/index.rb
@@ -5,7 +5,13 @@ module Portal
     include SearchableView
 
     def grid_view_active?
-      params[:view] == 'grid' || (within_collection? && collection.key == 'fashion')
+      if params[:view] == 'grid'
+        true
+      elsif !within_collection?
+        false
+      else
+        current_collection.settings['default_search_layout'] == 'grid'
+      end
     end
     alias_method :grid_view_active, :grid_view_active?
 

--- a/app/views/portal/index.rb
+++ b/app/views/portal/index.rb
@@ -207,7 +207,7 @@ module Portal
             name: collection.key,
             label: collection.landing_page.title,
             url: collection_url(collection),
-            def_view: collection.key == 'fashion' ? 'grid' : 'list'
+            def_view: collection.settings['default_search_layout']
           }
         end
       end

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -118,11 +118,13 @@ RailsAdmin.config do |config|
       field :title
       field :state
       field :api_params
+      field :settings_default_search_layout, :enum
     end
     edit do
       field :key
       field :title
       field :api_params
+      field :settings_default_search_layout, :enum
     end
   end
 

--- a/config/locales/rails.en.yml
+++ b/config/locales/rails.en.yml
@@ -3,6 +3,7 @@ en:
     attributes:
       collection:
         api_params: API parameters
+        settings_default_search_layout: Default search layout
       hero_image:
         settings_brand_colour: Brand colour
         settings_brand_opacity: Brand opacity

--- a/db/migrate/20160907132925_add_settings_to_collection.rb
+++ b/db/migrate/20160907132925_add_settings_to_collection.rb
@@ -1,0 +1,5 @@
+class AddSettingsToCollection < ActiveRecord::Migration
+  def change
+    add_column :collections, :settings, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160707092744) do
+ActiveRecord::Schema.define(version: 20160907132925) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -95,6 +95,7 @@ ActiveRecord::Schema.define(version: 20160707092744) do
     t.datetime "updated_at",                         null: false
     t.integer  "state",                  default: 0
     t.string   "title"
+    t.text     "settings"
   end
 
   create_table "delayed_jobs", force: :cascade do |t|

--- a/spec/fixtures/collections.yml
+++ b/spec/fixtures/collections.yml
@@ -17,3 +17,9 @@ draft:
   key: 'draft'
   api_params: 'qf=what:ever'
   state: 0
+
+grid_layout:
+  key: 'grid_layout'
+  api_params: 'qf=grid'
+  state: 1
+  settings: "--- !ruby/hash:ActiveSupport::HashWithIndifferentAccess\ndefault_search_layout: grid"

--- a/spec/fixtures/pages.yml
+++ b/spec/fixtures/pages.yml
@@ -30,6 +30,11 @@ art_collection:
   state: 0
   type: 'Page::Landing'
 
+grid_layout_collection:
+  slug: 'collections/grid_layout'
+  state: 1
+  type: 'Page::Landing'
+
 draft_landing_page:
   slug: 'draft'
   state: 0

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -3,6 +3,7 @@ RSpec.describe Collection do
   it { is_expected.to validate_presence_of(:key) }
   it { is_expected.to validate_uniqueness_of(:key) }
   it { is_expected.to validate_presence_of(:api_params) }
+  it { is_expected.to delegate_method(:settings_default_search_layout_enum).to(:class) }
 
   describe '#to_param' do
     context 'when key eq "music"' do
@@ -17,5 +18,10 @@ RSpec.describe Collection do
     it 'should enqueue a record counts job' do
       expect { subject }.to change { Delayed::Job.where("handler LIKE '%Cache::RecordCountsJob%'").count }.by(1)
     end
+  end
+
+  describe '.settings_default_search_layout_enum' do
+    subject { described_class.settings_default_search_layout_enum }
+    it { is_expected.to eq(%w(list grid)) }
   end
 end

--- a/spec/support/shared_contexts/blacklight_config.rb
+++ b/spec/support/shared_contexts/blacklight_config.rb
@@ -2,6 +2,8 @@ RSpec.shared_context 'Blacklight config', :blacklight_config do
   let(:blacklight_config) do
     Blacklight::Configuration.new do |config|
       config.index.title_field = 'title_display'
+      config.add_facet_field 'COLLECTION', include_in_request: false, single: true
+      config.add_facet_field 'TYPE', hierarchical: true
     end
   end
 

--- a/spec/views/portal/index_spec.rb
+++ b/spec/views/portal/index_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe 'portal/index.html.mustache', :common_view_components, :blackligh
     assign(:document_list, response.documents)
     assign(:params, blacklight_params)
     allow(view).to receive(:search_state).and_return(search_state)
+    allow(controller).to receive(:search_action_url).and_return('/search')
   end
 
   let(:api_response) do
@@ -60,6 +61,12 @@ RSpec.describe 'portal/index.html.mustache', :common_view_components, :blackligh
   end
 
   context 'when within a collection' do
+    before(:each) do
+      allow(view).to receive(:within_collection?).and_return(true)
+      allow(view).to receive(:current_collection).and_return(collection)
+      assign(:collection, collection)
+    end
+
     context 'with a default layout' do
       let(:collection) { collections(:grid_layout) }
       it 'sets that default layout' do

--- a/spec/views/portal/index_spec.rb
+++ b/spec/views/portal/index_spec.rb
@@ -58,4 +58,22 @@ RSpec.describe 'portal/index.html.mustache', :common_view_components, :blackligh
       end
     end
   end
+
+  context 'when within a collection' do
+    context 'with a default layout' do
+      let(:collection) { collections(:grid_layout) }
+      it 'sets that default layout' do
+        render
+        expect(rendered).to have_selector('body.display-grid')
+      end
+    end
+
+    context 'without a default layout' do
+      let(:collection) { collections(:art) }
+      it 'defaults layout to list' do
+        render
+        expect(rendered).not_to have_selector('body.display-grid')
+      end
+    end
+  end
 end


### PR DESCRIPTION
Requires a `db:migrate` to add settings attribute to Collection model.