### PR TITLE
Return nil if no feed image shown

### DIFF
--- a/app/helpers/feed_helper.rb
+++ b/app/helpers/feed_helper.rb
@@ -20,5 +20,6 @@ module FeedHelper
       mo = MediaObject.find_by_source_url_hash(MediaObject.hash_source_url(url))
       return mo.file.url(:medium) unless mo.nil?
     end
+    nil
   end
 end


### PR DESCRIPTION
Otherwise the return value is the enumerable passed to the block.