### PR TITLE
Add `FeedEntryImage` model

### DIFF
--- a/app/helpers/collections_helper.rb
+++ b/app/helpers/collections_helper.rb
@@ -61,7 +61,7 @@ module CollectionsHelper
         {
           url: CGI.unescapeHTML(item.url),
           img: {
-            src: feed_entry_img_src(item),
+            src: feed_entry_thumbnail_url(item),
             alt: item.title
           },
           title: false

--- a/app/helpers/feed_helper.rb
+++ b/app/helpers/feed_helper.rb
@@ -11,15 +11,7 @@ module FeedHelper
     end
   end
 
-  def feed_entry_img_src(item)
-    [:summary, :content].each do |method|
-      next unless item.send(method).present?
-      img_tag = item.send(method).match(/<img [^>]*>/i)
-      next unless img_tag.present?
-      url = img_tag[0].match(/src="(https?:\/\/[^"]*)"/i)[1]
-      mo = MediaObject.find_by_source_url_hash(MediaObject.hash_source_url(url))
-      return mo.file.url(:medium) unless mo.nil?
-    end
-    nil
+  def feed_entry_thumbnail_url(entry)
+    FeedEntryImage.new(entry).thumbnail_url
   end
 end

--- a/app/jobs/cache/feed/blog_job.rb
+++ b/app/jobs/cache/feed/blog_job.rb
@@ -4,17 +4,8 @@ module Cache
       def perform(url)
         super
         @feed.entries.each do |entry|
-          img_src = feed_entry_img_src(entry)
-          DownloadRemoteMediaObjectJob.perform_later(img_src) unless img_src.nil?
-        end
-      end
-
-      def feed_entry_img_src(entry)
-        [:summary, :content].each do |method|
-          next unless entry.send(method).present?
-          img_tag = entry.send(method).match(/<img [^>]*>/i)
-          next unless img_tag.present?
-          return img_tag[0].match(/src="(https?:\/\/[^"]*)"/i)[1]
+          img_url = FeedEntryImage.new(entry).media_object_url
+          DownloadRemoteMediaObjectJob.perform_later(img_url) unless img_url.nil?
         end
       end
     end

--- a/app/models/feed_entry_image.rb
+++ b/app/models/feed_entry_image.rb
@@ -58,7 +58,7 @@ class FeedEntryImage
 
   def first_url_attr_on_element(element_name, tag_name, attr_name)
     attr_value = first_attr_on_element(element_name, tag_name, attr_name)
-    (attr_value.present? && attr_value =~ %r{\Ahttps?://}) ? attr_value : nil
+    attr_value.present? && attr_value =~ %r{\Ahttps?://} ? attr_value : nil
   end
 
   def first_url_attr(tag_name, attr_name)

--- a/app/models/feed_entry_image.rb
+++ b/app/models/feed_entry_image.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+##
+# Models an image extracted from a remote RSS feed
+class FeedEntryImage
+  # Methods of `[Feedjira::Parser::RSSEntry]` feed entry to inspect for image
+  # URLs
+  ENTRY_ELEMENTS = %i(summary content).freeze
+
+  # HTML tag and attribute pairs to inspect for image URLs
+  TAGS_ATTRS = [
+    { tag: :img, attr: :src },
+    { tag: :video, attr: :poster }
+  ].freeze
+
+  # @param entry [Feedjira::Parser::RSSEntry]
+  def initialize(feed_entry)
+    @feed_entry = feed_entry
+  end
+
+  def thumbnail_url
+    media_object.present? ? media_object.file.url(:medium) : nil
+  end
+
+  def media_object
+    @media_object ||= begin
+      return nil if media_object_url.nil?
+      hash = MediaObject.hash_source_url(media_object_url)
+      MediaObject.find_by_source_url_hash(hash)
+    end
+  end
+
+  def media_object_url
+    @media_object_url ||= find_url_in_feed_entry
+  end
+
+  protected
+
+  def find_url_in_feed_entry
+    TAGS_ATTRS.each do |tag_attr|
+      url = first_url_attr(tag_attr[:tag], tag_attr[:attr])
+      return url unless url.nil?
+    end
+    nil
+  end
+
+  def element_html(element_name)
+    Nokogiri::HTML(@feed_entry.send(element_name))
+  end
+
+  def first_tag_in_element(element_name, tag_name)
+    element_html(element_name).css(tag_name).first
+  end
+
+  def first_attr_on_element(element_name, tag_name, attr_name)
+    first_tag = first_tag_in_element(element_name, tag_name)
+    first_tag.nil? ? nil : first_tag[attr_name]
+  end
+
+  def first_url_attr_on_element(element_name, tag_name, attr_name)
+    attr_value = first_attr_on_element(element_name, tag_name, attr_name)
+    (attr_value.present? && attr_value =~ %r{\Ahttps?://}) ? attr_value : nil
+  end
+
+  def first_url_attr(tag_name, attr_name)
+    ENTRY_ELEMENTS.each do |element_name|
+      url_attr = first_url_attr_on_element(element_name, tag_name, attr_name)
+      return url_attr unless url_attr.nil?
+    end
+    nil
+  end
+end

--- a/app/views/concerns/newsworthy_view.rb
+++ b/app/views/concerns/newsworthy_view.rb
@@ -14,7 +14,7 @@ module NewsworthyView
         },
         url: CGI.unescapeHTML(item.url),
         img: {
-          src: feed_entry_img_src(item),
+          src: feed_entry_thumbnail_url(item),
           alt: nil
         },
         excerpt: {


### PR DESCRIPTION
With support for extracting images from <video poster="..."/> attributes, e.g. for Tumblr.