### PR TITLE
Cache-proof sneak peak

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'rails', '4.2.7.1'
 
 # NB: this *must* be by Git ref; else will break asset versioning in
 #     config/initializers/assets.rb, preventing app startup
-gem 'europeana-styleguide', github: 'europeana/europeana-styleguide-ruby', ref: 'b06f2f4'
+gem 'europeana-styleguide', github: 'europeana/europeana-styleguide-ruby', ref: 'e51e55d'
 
 # Use a forked version of stache with downstream changes, until merged upstream
 # @see https://github.com/agoragames/stache/pulls/rwd

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,8 +24,8 @@ GIT
 
 GIT
   remote: git://github.com/europeana/europeana-styleguide-ruby.git
-  revision: b06f2f4ef9ce0fcbae21de0deebc7f7e9a9328e1
-  ref: b06f2f4
+  revision: e51e55d4268d37dbedce6c60ffaf1d1419ceed9f
+  ref: e51e55d
   specs:
     europeana-styleguide (0.2.0)
       activesupport (~> 4.0)
@@ -665,4 +665,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.13.1
+   1.12.5

--- a/app/views/collections/show.rb
+++ b/app/views/collections/show.rb
@@ -82,7 +82,7 @@ module Collections
           hero_config: hero_config(@landing_page.hero_image),
           entry_points: facet_entry_items_grouped(@landing_page),
           preview_search_data: preview_search_data,
-          preview_search_data_present: preview_search_data.size > 0,
+          preview_search_data_present: preview_search_data.present?,
           channel_entry: @landing_page.browse_entries.published.blank? ? nil : browse_entry_items_grouped(@landing_page.browse_entries.published, @landing_page),
           promoted: @landing_page.promotions.blank? ? nil : {
             items: promoted_items(@landing_page.promotions)

--- a/app/views/collections/show.rb
+++ b/app/views/collections/show.rb
@@ -82,6 +82,7 @@ module Collections
           hero_config: hero_config(@landing_page.hero_image),
           entry_points: facet_entry_items_grouped(@landing_page),
           preview_search_data: preview_search_data,
+          preview_search_data_present: preview_search_data.size > 0,
           channel_entry: @landing_page.browse_entries.published.blank? ? nil : browse_entry_items_grouped(@landing_page.browse_entries.published, @landing_page),
           promoted: @landing_page.promotions.blank? ? nil : {
             items: promoted_items(@landing_page.promotions)

--- a/app/views/collections/show.rb
+++ b/app/views/collections/show.rb
@@ -165,14 +165,13 @@ module Collections
     end
 
     def preview_search_data
-      if @landing_page.facet_entries.blank?
-        nil
-      else
-        random = @landing_page.facet_entries.sample
+      return nil if @landing_page.facet_entries.blank?
+
+      @landing_page.facet_entries.map do |facet_entry|
         {
-          preview_search_title: random.title,
-          preview_search_type: facet_entry_field_title(random),
-          preview_search_url: browse_entry_url(random, @landing_page, format: 'json')
+          preview_search_title: facet_entry.title,
+          preview_search_type: facet_entry_field_title(facet_entry),
+          preview_search_url: browse_entry_url(facet_entry, @landing_page, format: 'json')
         }
       end
     end


### PR DESCRIPTION
Because landing page HTML is cached and the facet entry needs to be
random, so the JS should pick one from all after each page load.