### PR TITLE
Gallery refinements

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ gem 'rails_admin', '~> 0.8.0'
 gem 'redis-rails', '~> 4.0'
 gem 'sass-rails'
 gem 'soundcloud', '~> 0.3'
+gem 'stringex', '~> 2.6'
 gem 'therubyracer'
 gem 'i18n_data'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -556,6 +556,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    stringex (2.6.1)
     sweet_notifications (0.2.1)
       activesupport (>= 4.0, < 6)
       railties (>= 4.0, < 6)
@@ -659,6 +660,7 @@ DEPENDENCIES
   soundcloud (~> 0.3)
   spring (~> 1.6)
   stache!
+  stringex (~> 2.6)
   therubyracer
   uglifier (~> 2.7.2)
   webmock (~> 1.22)

--- a/app/controllers/galleries_controller.rb
+++ b/app/controllers/galleries_controller.rb
@@ -6,7 +6,7 @@ class GalleriesController < ApplicationController
   end
 
   def show
-    @gallery = Gallery.find(params[:id])
+    @gallery = Gallery.find_by_slug(params[:id])
     @documents = search_api_for_image_metadata(@gallery.images)
   end
 

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -4,6 +4,7 @@ class Collection < ActiveRecord::Base
   include HasSettingsAttribute
 
   has_and_belongs_to_many :browse_entries
+  has_and_belongs_to_many :galleries, inverse_of: :collections
 
   has_paper_trail
 

--- a/app/models/gallery.rb
+++ b/app/models/gallery.rb
@@ -72,8 +72,8 @@ class Gallery < ActiveRecord::Base
   def ensure_unique_title
     i = 0
     unique_title = title
-    while !Gallery.where(title: unique_title).where.not(id: id).blank?
-      i = i + 1
+    until Gallery.where(title: unique_title).where.not(id: id).blank?
+      i += 1
       unique_title = "#{title} #{i}"
     end
     self.title = unique_title

--- a/app/models/gallery.rb
+++ b/app/models/gallery.rb
@@ -13,7 +13,11 @@ class Gallery < ActiveRecord::Base
 
   validates :title, presence: true, length: { maximum: 60 }
   validates :description, length: { maximum: 280 }
+  validates :slug, presence: true
   validate :validate_image_portal_urls
+
+  acts_as_url :title, url_attribute: :slug, only_when_blank: true,
+                      allow_duplicates: false
 
   default_scope { includes(:translations) }
 
@@ -25,6 +29,10 @@ class Gallery < ActiveRecord::Base
   # input field in the CMS.
   def image_portal_urls
     @image_portal_urls ||= images.map(&:portal_url).join("\n\n")
+  end
+
+  def to_param
+    slug
   end
 
   protected

--- a/app/models/gallery.rb
+++ b/app/models/gallery.rb
@@ -21,6 +21,7 @@ class Gallery < ActiveRecord::Base
 
   default_scope { includes(:translations) }
 
+  before_save :ensure_unique_title
   after_save :set_images_from_portal_urls
 
   attr_writer :image_portal_urls
@@ -64,5 +65,15 @@ class Gallery < ActiveRecord::Base
         errors.add(:image_portal_urls, %(not a Europeana record URL: "#{url}"))
       end
     end
+  end
+
+  def ensure_unique_title
+    i = 0
+    unique_title = title
+    while !Gallery.where(title: unique_title).where.not(id: id).blank?
+      i = i + 1
+      unique_title = "#{title} #{i}"
+    end
+    self.title = unique_title
   end
 end

--- a/app/models/gallery.rb
+++ b/app/models/gallery.rb
@@ -4,6 +4,8 @@ class Gallery < ActiveRecord::Base
 
   has_many :images, -> { order(:position) },
            class_name: 'GalleryImage', dependent: :destroy, inverse_of: :gallery
+  has_and_belongs_to_many :collections, inverse_of: :galleries
+
   accepts_nested_attributes_for :images, allow_destroy: true
 
   translates :title, :description, fallbacks_for_empty_translations: true

--- a/app/views/concerns/gallery_displaying_view.rb
+++ b/app/views/concerns/gallery_displaying_view.rb
@@ -17,8 +17,7 @@ module GalleryDisplayingView
     @presenters ||= {}
     @presenters[image.id] ||= begin
       document = document_for_gallery_image(image)
-      return nil if document.nil?
-      Document::SearchResultPresenter.new(document, controller)
+      document.nil? ? nil : Document::SearchResultPresenter.new(document, controller)
     end
   end
 

--- a/app/views/galleries/index.rb
+++ b/app/views/galleries/index.rb
@@ -3,6 +3,14 @@ module Galleries
   class Index < ApplicationView
     include GalleryDisplayingView
 
+    def bodyclass
+      'channel_landing'
+    end
+
+    def js_vars
+      [{ name: 'pageName', value: 'collections/galleries' }]
+    end
+
     def content
       {
         galleries: galleries_content

--- a/app/views/galleries/show.rb
+++ b/app/views/galleries/show.rb
@@ -3,6 +3,14 @@ module Galleries
   class Show < ApplicationView
     include GalleryDisplayingView
 
+    def bodyclass
+      'channel_landing'
+    end
+
+    def js_vars
+      [{ name: 'pageName', value: 'collections/galleries' }]
+    end
+
     def content
       {
         galleries_link: galleries_path,

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -198,6 +198,9 @@ RailsAdmin.config do |config|
     edit do
       field :title
       field :description, :text
+      field :collections do
+        inline_add false
+      end
       field :image_portal_urls, :text do
         html_attributes rows: 15, cols: 80
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,8 +29,6 @@ Rails.application.routes.draw do
       get 'tumblr', on: :member
     end
 
-    resources :galleries, only: [:show, :index]
-
     get 'channels', to: redirect('%{locale}/collections')
     get 'channels/:id', to: redirect('%{locale}/collections/%{id}')
 
@@ -52,6 +50,10 @@ Rails.application.routes.draw do
     get 'explore/sources', to: 'explore#sources'
     get 'explore/topics', to: 'explore#topics'
     get 'explore/periods', to: 'explore#periods'
+
+    scope '/explore' do
+      resources :galleries, only: [:show, :index]
+    end
 
     get 'entities/suggest'
 

--- a/db/migrate/20170131150633_add_slug_to_gallery.rb
+++ b/db/migrate/20170131150633_add_slug_to_gallery.rb
@@ -1,0 +1,6 @@
+class AddSlugToGallery < ActiveRecord::Migration
+  def change
+    add_column :galleries, :slug, :text
+    add_index :galleries, :slug, unique: true
+  end
+end

--- a/db/migrate/20170131150633_add_slug_to_gallery.rb
+++ b/db/migrate/20170131150633_add_slug_to_gallery.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class AddSlugToGallery < ActiveRecord::Migration
   def change
     add_column :galleries, :slug, :text

--- a/db/migrate/20170131154042_associate_gallery_with_collection.rb
+++ b/db/migrate/20170131154042_associate_gallery_with_collection.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+class AssociateGalleryWithCollection < ActiveRecord::Migration
+  def change
+    create_table :collections_galleries do |t|
+      t.belongs_to :collection, index: true
+      t.belongs_to :gallery, index: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170131150633) do
+ActiveRecord::Schema.define(version: 20170131154042) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -101,6 +101,14 @@ ActiveRecord::Schema.define(version: 20170131150633) do
     t.text     "settings"
     t.string   "newsletter_url"
   end
+
+  create_table "collections_galleries", force: :cascade do |t|
+    t.integer "collection_id"
+    t.integer "gallery_id"
+  end
+
+  add_index "collections_galleries", ["collection_id"], name: "index_collections_galleries_on_collection_id", using: :btree
+  add_index "collections_galleries", ["gallery_id"], name: "index_collections_galleries_on_gallery_id", using: :btree
 
   create_table "data_provider_logos", force: :cascade do |t|
     t.integer  "data_provider_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170126103123) do
+ActiveRecord::Schema.define(version: 20170131150633) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -153,8 +153,10 @@ ActiveRecord::Schema.define(version: 20170126103123) do
     t.integer  "state",      default: 0
     t.datetime "created_at",             null: false
     t.datetime "updated_at",             null: false
+    t.text     "slug"
   end
 
+  add_index "galleries", ["slug"], name: "index_galleries_on_slug", unique: true, using: :btree
   add_index "galleries", ["state"], name: "index_galleries_on_state", using: :btree
 
   create_table "gallery_images", force: :cascade do |t|

--- a/spec/controllers/galleries_controller_spec.rb
+++ b/spec/controllers/galleries_controller_spec.rb
@@ -35,17 +35,17 @@ RSpec.describe GalleriesController do
       let(:gallery) { Gallery.published.first }
 
       it 'returns http success' do
-        get :show, locale: 'en', id: gallery.id
+        get :show, locale: 'en', id: gallery.slug
         expect(response).to have_http_status(:success)
       end
 
       it 'assigns gallery to @gallery' do
-        get :show, locale: 'en', id: gallery.id
+        get :show, locale: 'en', id: gallery.slug
         expect(assigns[:gallery]).to eq(gallery)
       end
 
       it 'searches the API for the gallery image metadata' do
-        get :show, locale: 'en', id: gallery.id
+        get :show, locale: 'en', id: gallery.slug
         ids = gallery.images.map(&:europeana_record_id)
         api_query = %[europeana_id:("#{ids.join('" OR "')}")]
         expect(an_api_search_request.

--- a/spec/fixtures/galleries.yml
+++ b/spec/fixtures/galleries.yml
@@ -1,8 +1,11 @@
 draft:
   state: 0
+  slug: draft
 
 empty:
   state: 1
+  slug: empty
 
 fashion_dresses:
   state: 1
+  slug: fashion-dresses

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe Collection do
   it { is_expected.to have_and_belong_to_many(:browse_entries) }
+  it { is_expected.to have_and_belong_to_many(:galleries).inverse_of(:collections) }
   it { is_expected.to validate_presence_of(:key) }
   it { is_expected.to validate_uniqueness_of(:key) }
   it { is_expected.to validate_presence_of(:api_params) }

--- a/spec/models/gallery_spec.rb
+++ b/spec/models/gallery_spec.rb
@@ -16,6 +16,15 @@ RSpec.describe Gallery do
     expect(described_class.translated_attribute_names).to include(:title)
   end
 
+  it 'should enforce unique titles' do
+    g1 = Gallery.create(title: 'Stuff')
+    g2 = Gallery.create(title: 'Stuff')
+    g3 = Gallery.create(title: 'Stuff')
+    expect(g1.reload.title).to eq('Stuff')
+    expect(g2.reload.title).to eq('Stuff 1')
+    expect(g3.reload.title).to eq('Stuff 2')
+  end
+
   it 'should translate description' do
     expect(described_class.translated_attribute_names).to include(:description)
   end

--- a/spec/models/gallery_spec.rb
+++ b/spec/models/gallery_spec.rb
@@ -20,6 +20,13 @@ RSpec.describe Gallery do
     expect(described_class.translated_attribute_names).to include(:description)
   end
 
+  describe '#to_param' do
+    it 'should return the slug' do
+      gallery = Gallery.new(title: 'Pianos', slug: 'pianos')
+      expect(gallery.to_param).to eq('pianos')
+    end
+  end
+
   describe '#image_portal_urls' do
     it 'should return a new line-separated list of gallery image record URLs' do
       expect(galleries(:fashion_dresses).image_portal_urls).to eq("http://www.europeana.eu/portal/record/dresses/1.html\n\nhttp://www.europeana.eu/portal/record/dresses/2.html")

--- a/spec/models/gallery_spec.rb
+++ b/spec/models/gallery_spec.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 RSpec.describe Gallery do
   it { is_expected.to have_many(:images).inverse_of(:gallery).dependent(:destroy) }
+  it { is_expected.to have_and_belong_to_many(:collections).inverse_of(:galleries) }
   it { is_expected.to validate_presence_of(:title) }
-  it { should validate_length_of(:title).is_at_most(60) }
-  it { should validate_length_of(:description).is_at_most(280) }
+  it { is_expected.to validate_length_of(:title).is_at_most(60) }
+  it { is_expected.to validate_length_of(:description).is_at_most(280) }
   it { is_expected.to be_versioned }
-  it { should accept_nested_attributes_for(:images).allow_destroy(true) }
-  it { should accept_nested_attributes_for(:translations).allow_destroy(true) }
+  it { is_expected.to accept_nested_attributes_for(:images).allow_destroy(true) }
+  it { is_expected.to accept_nested_attributes_for(:translations).allow_destroy(true) }
 
   it 'should have publication states' do
     expect(described_class).to include(HasPublicationStates)

--- a/spec/routing/galleries_routing_spec.rb
+++ b/spec/routing/galleries_routing_spec.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 RSpec.describe 'routes for the galleries controller' do
-  it 'routes GET /en/galleries to galleries#index' do
-    expect(get('/en/galleries')).to route_to('galleries#index', locale: 'en')
+  it 'routes GET /en/explore/galleries to galleries#index' do
+    expect(get('/en/explore/galleries')).to route_to('galleries#index', locale: 'en')
   end
 
-  it 'routes GET /en/galleries/high-heels to galleries#show' do
-    expect(get('/en/galleries/high-heels')).to route_to('galleries#show', locale: 'en', id: 'high-heels')
+  it 'routes GET /en/explore/galleries/high-heels to galleries#show' do
+    expect(get('/en/explore/galleries/high-heels')).to route_to('galleries#show', locale: 'en', id: 'high-heels')
   end
 end


### PR DESCRIPTION
* Associate galleries with collections to support "themed" galleries
* Galleries have unique titles enforced not by validation but by the `Gallery` model automatically appending a number to the end of the title until it is unique
* Galleries have slugs used in their URLs, auto-generated by the stringex gem
* Gallery index and show page URLs are beneath /explore