### PR TITLE
Load data provider on item page

### DIFF
--- a/app/controllers/portal_controller.rb
+++ b/app/controllers/portal_controller.rb
@@ -85,7 +85,7 @@ class PortalController < ApplicationController
   protected
 
   def document_data_provider(document)
-    data_provider_name = document.fetch('aggregations.edmDataProvider').first
+    data_provider_name = document.fetch('aggregations.edmDataProvider', []).first
     DataProvider.find_by_name(data_provider_name)
   end
 

--- a/app/controllers/portal_controller.rb
+++ b/app/controllers/portal_controller.rb
@@ -43,6 +43,8 @@ class PortalController < ApplicationController
   # GET /record/:id
   def show
     @response, @document = fetch(doc_id, api_query_params)
+    @data_provider = document_data_provider(@document)
+
     @url_conversions = perform_url_conversions(@document)
     @oembed_html = oembed_for_urls(@document, @url_conversions)
 
@@ -81,6 +83,11 @@ class PortalController < ApplicationController
   end
 
   protected
+
+  def document_data_provider(document)
+    data_provider_name = document.fetch('aggregations.edmDataProvider').first
+    DataProvider.find_by_name(data_provider_name)
+  end
 
   def find_landing_page
     Page::Landing.find_or_initialize_by(slug: '').tap do |landing_page|

--- a/app/views/portal/show.rb
+++ b/app/views/portal/show.rb
@@ -402,6 +402,11 @@ module Portal
 
     protected
 
+    def data_provider_logo_url
+      return nil unless @data_provider.present? && @data_provider.image.present?
+      @data_provider.image.url(:medium)
+    end
+
     def similar_items_item(doc)
       presenter = Document::SearchResultPresenter.new(doc, controller)
       {

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -153,7 +153,7 @@ RailsAdmin.config do |config|
       field :uri
       field :name
       field :image, :paperclip do
-        help 'Minimum 300px in width, transparent & greyscale'
+        help 'transparent & greyscale'
         thumb_method :medium
       end
     end

--- a/spec/controllers/portal_controller_spec.rb
+++ b/spec/controllers/portal_controller_spec.rb
@@ -108,6 +108,16 @@ RSpec.describe PortalController do
       expect(assigns(:document)).to eq(assigns(:response).documents.first)
     end
 
+    context 'with edm:dataProvider' do
+      before do
+        get :show, params
+      end
+      let(:params) { { locale: 'en', id: 'with/edm:dataProvider' } }
+      it 'assigns the data provider to @data_provider' do
+        expect(assigns(:data_provider)).to eq(data_providers(:anonymous))
+      end
+    end
+
     it 'assigns similar items to @similar' do
       get :show, params
       expect(assigns(:similar)).to be_a(Array)

--- a/spec/fixtures/api_response/record_with_edm_dataprovider.json.erb
+++ b/spec/fixtures/api_response/record_with_edm_dataprovider.json.erb
@@ -1,0 +1,19 @@
+{
+  "success": true,
+  "object": {
+    "about": "<%= id %>",
+    "title": ["<%= id %>"],
+    "proxies": [
+      {
+        "dcCreator": {
+          "def": ["Mister Smith"]
+        }
+      }
+    ],
+    "aggregations": [
+      {
+        "edmDataProvider": { "def": [ "Anonymous" ] }
+      }
+    ]
+  }
+}

--- a/spec/fixtures/data_providers.yml
+++ b/spec/fixtures/data_providers.yml
@@ -1,0 +1,2 @@
+anonymous:
+  name: Anonymous

--- a/spec/support/helpers/europeana_api_helper.rb
+++ b/spec/support/helpers/europeana_api_helper.rb
@@ -81,6 +81,17 @@ module EuropeanaAPIHelper
           }
         end
 
+      # Record with edm:dataProvider in aggregation
+      stub_request(:get, %r{#{Europeana::API.url}/v2/record/with/edm:dataProvider.json}).
+        with(query: hash_including(wskey: ENV['EUROPEANA_API_KEY'])).
+        to_return do |request|
+          {
+            body: api_responses(:record_with_edm_dataprovider, id: record_id_from_request_uri(request)),
+            status: 200,
+            headers: { 'Content-Type' => 'application/json' }
+          }
+        end
+
       # Hierarchy API
       stub_request(:get, %r{#{Europeana::API.url}/v2/record/[^/]+/[^/]+/(self|parent|children|ancestor-self-siblings|precee?ding-siblings|following-siblings).json}).
         with(query: hash_including(wskey: ENV['EUROPEANA_API_KEY'])).


### PR DESCRIPTION
Re: https://europeanadev.assembla.com/spaces/europeana-npc/tickets/1841

You will need to enter the CMS and upload a logo for one of the pre-populated Fashion data providers, e.g. Pucci Archive. When you then view the item page for an item from that data provider, e.g. /2048205/SC0215701, then a variable `@data_provider` is available to the view, and the view method `#data_provider_logo_url` can be used to get the URL of the logo image.
