### PR TITLE
Topics & Categorisations

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -28,6 +28,6 @@ class Ability
     can :access, :rails_admin
     can :dashboard
     can :manage, [Banner, BrowseEntry, Collection, DataProvider, Gallery,
-                  HeroImage, Link, MediaObject, Page, User]
+                  HeroImage, Link, MediaObject, Page, Topic, User]
   end
 end

--- a/app/models/categorisation.rb
+++ b/app/models/categorisation.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+class Categorisation < ActiveRecord::Base
+  belongs_to :categorisable, polymorphic: true
+  belongs_to :topic, inverse_of: :categorisations
+
+  validates :topic_id, presence: true
+  validates :categorisable, presence: true
+
+  default_scope { includes(:topic) }
+
+  def topic_name
+    topic.name
+  end
+end

--- a/app/models/categorisation.rb
+++ b/app/models/categorisation.rb
@@ -8,7 +8,7 @@ class Categorisation < ActiveRecord::Base
 
   default_scope { includes(:topic) }
 
-  def topic_name
-    topic.name
+  def topic_label
+    topic.label
   end
 end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -4,7 +4,6 @@ class Collection < ActiveRecord::Base
   include HasSettingsAttribute
 
   has_and_belongs_to_many :browse_entries
-  has_and_belongs_to_many :galleries, inverse_of: :collections
 
   has_paper_trail
 

--- a/app/models/concerns/is_categorisable.rb
+++ b/app/models/concerns/is_categorisable.rb
@@ -3,8 +3,12 @@ module IsCategorisable
   extend ActiveSupport::Concern
 
   included do
-    has_one :categorisation, as: :categorisable
-    has_one :topic, through: :categorisation
-    accepts_nested_attributes_for :categorisation
+    has_many :categorisations, as: :categorisable
+    has_many :topics, through: :categorisations
+    accepts_nested_attributes_for :categorisations
+  end
+
+  def topic_ids_enum
+    Topic.all.sort_by(&:label).map { |topic| [topic.label, topic.id] }
   end
 end

--- a/app/models/concerns/is_categorisable.rb
+++ b/app/models/concerns/is_categorisable.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+module IsCategorisable
+  extend ActiveSupport::Concern
+
+  included do
+    has_one :categorisation, as: :categorisable
+    has_one :topic, through: :categorisation
+    accepts_nested_attributes_for :categorisation
+  end
+end

--- a/app/models/gallery.rb
+++ b/app/models/gallery.rb
@@ -151,7 +151,7 @@ class Gallery < ActiveRecord::Base
 
   def validate_number_of_categorisations
     if categorisations.size > 3
-      errors.add(:categorisations, "can have at most 3 topics")
+      errors.add(:categorisations, 'can have at most 3 topics')
     end
   end
 end

--- a/app/models/gallery.rb
+++ b/app/models/gallery.rb
@@ -20,6 +20,8 @@ class Gallery < ActiveRecord::Base
   validates :slug, presence: true
   validate :validate_image_portal_urls
   validate :validate_number_of_image_portal_urls
+  # @todo move this into a configurable class method in `IsCategorisable`
+  validate :validate_number_of_categorisations
 
   acts_as_url :title, url_attribute: :slug, only_when_blank: true,
                       allow_duplicates: false
@@ -87,5 +89,11 @@ class Gallery < ActiveRecord::Base
       unique_title = "#{title} #{i}"
     end
     self.title = unique_title
+  end
+
+  def validate_number_of_categorisations
+    if categorisations.size > 3
+      errors.add(:categorisations, "can have at most 3 topics")
+    end
   end
 end

--- a/app/models/gallery.rb
+++ b/app/models/gallery.rb
@@ -3,10 +3,10 @@ class Gallery < ActiveRecord::Base
   NUMBER_OF_IMAGES = 6..24
 
   include HasPublicationStates
+  include IsCategorisable
 
   has_many :images, -> { order(:position) },
            class_name: 'GalleryImage', dependent: :destroy, inverse_of: :gallery
-  has_and_belongs_to_many :collections, inverse_of: :galleries
 
   accepts_nested_attributes_for :images, allow_destroy: true
 

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -9,7 +9,7 @@ class Topic < ActiveRecord::Base
   accepts_nested_attributes_for :translations, allow_destroy: true
 
   acts_as_url :label, url_attribute: :slug, only_when_blank: true,
-                     allow_duplicates: false
+                      allow_duplicates: false
 
   default_scope { includes(:translations).order('topic_translations.label') }
 

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1,5 +1,19 @@
 # frozen_string_literal: true
 class Topic < ActiveRecord::Base
+  has_many :categorisations, inverse_of: :topic, dependent: :destroy
+
+  validates :name, presence: true, uniqueness: true
+  validates :entity_uri, uniqueness: true, allow_blank: true
+
   translates :name, fallbacks_for_empty_translations: true
   accepts_nested_attributes_for :translations, allow_destroy: true
+
+  acts_as_url :name, url_attribute: :slug, only_when_blank: true,
+                     allow_duplicates: false
+
+  default_scope { includes(:translations).order('topic_translations.name') }
+
+  def to_param
+    slug
+  end
 end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+class Topic < ActiveRecord::Base
+  translates :name, fallbacks_for_empty_translations: true
+  accepts_nested_attributes_for :translations, allow_destroy: true
+end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -2,16 +2,16 @@
 class Topic < ActiveRecord::Base
   has_many :categorisations, inverse_of: :topic, dependent: :destroy
 
-  validates :name, presence: true, uniqueness: true
+  validates :label, presence: true, uniqueness: true
   validates :entity_uri, uniqueness: true, allow_blank: true
 
-  translates :name, fallbacks_for_empty_translations: true
+  translates :label, fallbacks_for_empty_translations: true
   accepts_nested_attributes_for :translations, allow_destroy: true
 
-  acts_as_url :name, url_attribute: :slug, only_when_blank: true,
+  acts_as_url :label, url_attribute: :slug, only_when_blank: true,
                      allow_duplicates: false
 
-  default_scope { includes(:translations).order('topic_translations.name') }
+  default_scope { includes(:translations).order('topic_translations.label') }
 
   def to_param
     slug

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -11,7 +11,7 @@ class Topic < ActiveRecord::Base
   acts_as_url :label, url_attribute: :slug, only_when_blank: true,
                       allow_duplicates: false
 
-  default_scope { includes(:translations).order('topic_translations.label') }
+  default_scope { includes(:translations) }
 
   def to_param
     slug

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -449,19 +449,19 @@ RailsAdmin.config do |config|
 
   config.model 'Topic' do
     list do
-      field :name do
-        searchable 'topic_translations.name'
+      field :label do
+        searchable 'topic_translations.label'
         queryable true
         filterable true
       end
       field :entity_uri
     end
     show do
-      field :name
+      field :label
       field :entity_uri
     end
     edit do
-      field :name
+      field :label
       field :entity_uri, :string
     end
   end

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -448,6 +448,7 @@ RailsAdmin.config do |config|
   end
 
   config.model 'Topic' do
+    object_label_method :label
     list do
       field :label do
         searchable 'topic_translations.label'

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -18,9 +18,9 @@ RailsAdmin.config do |config|
   config.audit_with :paper_trail, 'User', 'PaperTrail::Version'
 
   config.included_models = %w(
-    Banner BrowseEntry Collection DataProvider DataProviderLogo FacetLinkGroup
+    Banner BrowseEntry Categorisation Collection DataProvider DataProviderLogo FacetLinkGroup
     Gallery HeroImage Link Link::Promotion Link::Credit Link::SocialMedia
-    MediaObject Page Page::Error Page::Landing User
+    MediaObject Page Page::Error Page::Landing Topic User
   )
 
   config.actions do
@@ -100,6 +100,17 @@ RailsAdmin.config do |config|
       field :subject_type
       field :collections do
         inline_add false
+      end
+    end
+  end
+
+  config.model 'Categorisation' do
+    object_label_method :topic_name
+    visible false
+    edit do
+      field :topic do
+        inline_add false
+        inline_edit false
       end
     end
   end
@@ -198,9 +209,7 @@ RailsAdmin.config do |config|
     edit do
       field :title
       field :description, :text
-      field :collections do
-        inline_add false
-      end
+      field :categorisation
       field :image_portal_urls, :text do
         html_attributes rows: 15, cols: 80
       end
@@ -435,6 +444,25 @@ RailsAdmin.config do |config|
         end
       end
       field :banner
+    end
+  end
+
+  config.model 'Topic' do
+    list do
+      field :name do
+        searchable 'topic_translations.name'
+        queryable true
+        filterable true
+      end
+      field :entity_uri
+    end
+    show do
+      field :name
+      field :entity_uri
+    end
+    edit do
+      field :name
+      field :entity_uri, :string
     end
   end
 

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -105,7 +105,7 @@ RailsAdmin.config do |config|
   end
 
   config.model 'Categorisation' do
-    object_label_method :topic_name
+    object_label_method :topic_label
     visible false
     edit do
       field :topic do

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -18,7 +18,7 @@ RailsAdmin.config do |config|
   config.audit_with :paper_trail, 'User', 'PaperTrail::Version'
 
   config.included_models = %w(
-    Banner BrowseEntry Categorisation Collection DataProvider DataProviderLogo FacetLinkGroup
+    Banner BrowseEntry Collection DataProvider DataProviderLogo FacetLinkGroup
     Gallery HeroImage Link Link::Promotion Link::Credit Link::SocialMedia
     MediaObject Page Page::Error Page::Landing Topic User
   )
@@ -100,20 +100,6 @@ RailsAdmin.config do |config|
       field :subject_type
       field :collections do
         inline_add false
-      end
-    end
-  end
-
-  config.model 'Categorisation' do
-    object_label_method :topic_label
-    visible false
-    edit do
-      field :topic, :enum do
-        enum do
-          Topic.where('topic_translations.locale=?', I18n.locale).map { |topic| [topic.label, topic.id] }
-        end
-        inline_add false
-        inline_edit false
       end
     end
   end
@@ -212,7 +198,9 @@ RailsAdmin.config do |config|
     edit do
       field :title
       field :description, :text
-      field :categorisation
+      field :topic_ids, :enum do
+        multiple true
+      end
       field :image_portal_urls, :text do
         html_attributes rows: 15, cols: 80
       end

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -108,7 +108,10 @@ RailsAdmin.config do |config|
     object_label_method :topic_label
     visible false
     edit do
-      field :topic do
+      field :topic, :enum do
+        enum do
+          Topic.where('topic_translations.locale=?', I18n.locale).map { |topic| [topic.label, topic.id] }
+        end
         inline_add false
         inline_edit false
       end

--- a/config/locales/rails.en.yml
+++ b/config/locales/rails.en.yml
@@ -29,6 +29,8 @@ en:
       page:
         settings_full_width: Full width?
         settings_layout_type: Layout
+      topic:
+        entity_uri: Entity Collection URI
     models:
       page/error:
         one: Error Page

--- a/db/migrate/20170207155507_create_topics.rb
+++ b/db/migrate/20170207155507_create_topics.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+class CreateTopics < ActiveRecord::Migration
+  def change
+    create_table :topics do |t|
+      t.string :slug, index: true
+      t.text :entity_uri
+      t.timestamps null: false
+    end
+
+    reversible do |dir|
+      dir.up do
+        Topic.create_translation_table! name: :string
+      end
+
+      dir.down do
+        Topic.drop_translation_table!
+      end
+    end
+  end
+end

--- a/db/migrate/20170207155507_create_topics.rb
+++ b/db/migrate/20170207155507_create_topics.rb
@@ -9,7 +9,7 @@ class CreateTopics < ActiveRecord::Migration
 
     reversible do |dir|
       dir.up do
-        Topic.create_translation_table! name: :string
+        Topic.create_translation_table! label: :string
       end
 
       dir.down do

--- a/db/migrate/20170208102105_create_categorisations.rb
+++ b/db/migrate/20170208102105_create_categorisations.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+class CreateCategorisations < ActiveRecord::Migration
+  def change
+    create_table :categorisations do |t|
+      t.integer :topic_id, index: true
+      t.references :categorisable, polymorphic: true
+      t.index [:categorisable_type, :categorisable_id], name: :index_categorisations_on_categorisable
+      t.timestamps null: false
+    end
+    add_foreign_key :categorisations, :topics
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170131154042) do
+ActiveRecord::Schema.define(version: 20170207155507) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -290,6 +290,26 @@ ActiveRecord::Schema.define(version: 20170131154042) do
   end
 
   add_index "searches", ["user_id"], name: "index_searches_on_user_id", using: :btree
+
+  create_table "topic_translations", force: :cascade do |t|
+    t.integer  "topic_id",   null: false
+    t.string   "locale",     null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string   "name"
+  end
+
+  add_index "topic_translations", ["locale"], name: "index_topic_translations_on_locale", using: :btree
+  add_index "topic_translations", ["topic_id"], name: "index_topic_translations_on_topic_id", using: :btree
+
+  create_table "topics", force: :cascade do |t|
+    t.string   "slug"
+    t.text     "entity_uri"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_index "topics", ["slug"], name: "index_topics_on_slug", using: :btree
 
   create_table "users", force: :cascade do |t|
     t.string   "email",                  limit: 255, default: "",    null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170207155507) do
+ActiveRecord::Schema.define(version: 20170208102105) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -79,6 +79,17 @@ ActiveRecord::Schema.define(version: 20170207155507) do
 
   add_index "browse_entry_translations", ["browse_entry_id"], name: "index_browse_entry_translations_on_browse_entry_id", using: :btree
   add_index "browse_entry_translations", ["locale"], name: "index_browse_entry_translations_on_locale", using: :btree
+
+  create_table "categorisations", force: :cascade do |t|
+    t.integer  "topic_id"
+    t.integer  "categorisable_id"
+    t.string   "categorisable_type"
+    t.datetime "created_at",         null: false
+    t.datetime "updated_at",         null: false
+  end
+
+  add_index "categorisations", ["categorisable_type", "categorisable_id"], name: "index_categorisations_on_categorisable", using: :btree
+  add_index "categorisations", ["topic_id"], name: "index_categorisations_on_topic_id", using: :btree
 
   create_table "collection_translations", force: :cascade do |t|
     t.integer  "collection_id", null: false
@@ -357,6 +368,7 @@ ActiveRecord::Schema.define(version: 20170207155507) do
   add_foreign_key "browse_entries", "facet_link_groups"
   add_foreign_key "browse_entries_collections", "browse_entries"
   add_foreign_key "browse_entries_collections", "collections"
+  add_foreign_key "categorisations", "topics"
   add_foreign_key "facet_link_groups", "pages"
   add_foreign_key "gallery_images", "galleries"
   add_foreign_key "page_elements", "pages"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -307,7 +307,7 @@ ActiveRecord::Schema.define(version: 20170208102105) do
     t.string   "locale",     null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string   "name"
+    t.string   "label"
   end
 
   add_index "topic_translations", ["locale"], name: "index_topic_translations_on_locale", using: :btree

--- a/db/seeds/topics.rb
+++ b/db/seeds/topics.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 YAML.load_file(File.expand_path('../topics.yml', __FILE__)).each do |attrs|
   ActiveRecord::Base.transaction do
-    print %(Seeding topic with name "#{attrs[:name].bold}": )
-    if topic = Topic.find_by(name: attrs[:name])
+    print %(Seeding topic with label "#{attrs[:label].bold}": )
+    if topic = Topic.find_by(label: attrs[:label])
       topic.update_attributes(attrs)
       puts 'topic exists; updated OK'.green
     else

--- a/db/seeds/topics.rb
+++ b/db/seeds/topics.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+YAML.load_file(File.expand_path('../topics.yml', __FILE__)).each do |attrs|
+  ActiveRecord::Base.transaction do
+    print %(Seeding topic with name "#{attrs[:name].bold}": )
+    if topic = Topic.find_by(name: attrs[:name])
+      topic.update_attributes(attrs)
+      puts 'topic exists; updated OK'.green
+    else
+      Topic.create!(attrs)
+      puts 'topic created OK'.green
+    end
+  end
+end

--- a/db/seeds/topics.yml
+++ b/db/seeds/topics.yml
@@ -1,28 +1,28 @@
 ---
-- :name: Archaeology
+- :label: Archaeology
   :entity_uri: http://data.europeana.eu/concept/base/80
-- :name: Architecture
+- :label: Architecture
   :entity_uri: http://data.europeana.eu/concept/base/94
-- :name: Art
+- :label: Art
   :entity_uri: http://data.europeana.eu/concept/base/190
-- :name: Fashion
-- :name: First World War
+- :label: Fashion
+- :label: First World War
   :entity_uri: http://data.europeana.eu/concept/base/83
-- :name: Food and Drink
+- :label: Food and Drink
   :entity_uri: http://data.europeana.eu/concept/base/124
-- :name: History
+- :label: History
   :entity_uri: http://data.europeana.eu/concept/base/79
-- :name: History of Science
-- :name: History of Travel
-- :name: Literature
-- :name: Maps and Cartography
+- :label: History of Science
+- :label: History of Travel
+- :label: Literature
+- :label: Maps and Cartography
   :entity_uri: http://data.europeana.eu/concept/base/43
-- :name: Migration
+- :label: Migration
   :entity_uri: http://data.europeana.eu/concept/base/128
-- :name: Military history
-- :name: Music
+- :label: Military history
+- :label: Music
   :entity_uri: http://data.europeana.eu/concept/base/62
-- :name: Natural history
+- :label: Natural history
   :entity_uri: http://data.europeana.eu/concept/base/156
-- :name: Performing Arts
-- :name: Photography
+- :label: Performing Arts
+- :label: Photography

--- a/db/seeds/topics.yml
+++ b/db/seeds/topics.yml
@@ -1,0 +1,28 @@
+---
+- :name: Archaeology
+  :entity_uri: http://data.europeana.eu/concept/base/80
+- :name: Architecture
+  :entity_uri: http://data.europeana.eu/concept/base/94
+- :name: Art
+  :entity_uri: http://data.europeana.eu/concept/base/190
+- :name: Fashion
+- :name: First World War
+  :entity_uri: http://data.europeana.eu/concept/base/83
+- :name: Food and Drink
+  :entity_uri: http://data.europeana.eu/concept/base/124
+- :name: History
+  :entity_uri: http://data.europeana.eu/concept/base/79
+- :name: History of Science
+- :name: History of Travel
+- :name: Literature
+- :name: Maps and Cartography
+  :entity_uri: http://data.europeana.eu/concept/base/43
+- :name: Migration
+  :entity_uri: http://data.europeana.eu/concept/base/128
+- :name: Military history
+- :name: Music
+  :entity_uri: http://data.europeana.eu/concept/base/62
+- :name: Natural history
+  :entity_uri: http://data.europeana.eu/concept/base/156
+- :name: Performing Arts
+- :name: Photography

--- a/spec/config/initializers/rails_admin_spec.rb
+++ b/spec/config/initializers/rails_admin_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe RailsAdmin.config do
   describe '#included_models' do
     subject { RailsAdmin.config.included_models }
-    it { is_expected.to eq(%w(Banner BrowseEntry Collection DataProvider DataProviderLogo FacetLinkGroup Gallery HeroImage Link Link::Promotion Link::Credit Link::SocialMedia MediaObject Page Page::Error Page::Landing User)) }
+    it { is_expected.to eq(%w(Banner BrowseEntry Collection DataProvider DataProviderLogo FacetLinkGroup Gallery HeroImage Link Link::Promotion Link::Credit Link::SocialMedia MediaObject Page Page::Error Page::Landing Topic User)) }
   end
 
   describe '#model' do
@@ -81,6 +81,14 @@ RSpec.describe RailsAdmin.config do
 
     context 'when model is Page::Landing' do
       let(:model_name) { 'Page::Landing' }
+      describe '.visible' do
+        subject { model.visible }
+        it { is_expected.to be true }
+      end
+    end
+
+    context 'when model is Topic' do
+      let(:model_name) { 'Topic' }
       describe '.visible' do
         subject { model.visible }
         it { is_expected.to be true }

--- a/spec/config/initializers/rails_admin_spec.rb
+++ b/spec/config/initializers/rails_admin_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe RailsAdmin.config do
   describe '#included_models' do
     subject { RailsAdmin.config.included_models }
-    it { is_expected.to eq(%w(Banner BrowseEntry Categorisation Collection DataProvider DataProviderLogo FacetLinkGroup Gallery HeroImage Link Link::Promotion Link::Credit Link::SocialMedia MediaObject Page Page::Error Page::Landing Topic User)) }
+    it { is_expected.to eq(%w(Banner BrowseEntry Collection DataProvider DataProviderLogo FacetLinkGroup Gallery HeroImage Link Link::Promotion Link::Credit Link::SocialMedia MediaObject Page Page::Error Page::Landing Topic User)) }
   end
 
   describe '#model' do
@@ -16,7 +16,7 @@ RSpec.describe RailsAdmin.config do
       end
     end
 
-    %w(Categorisation HeroImage Link MediaObject).each do |model_name|
+    %w(HeroImage Link MediaObject).each do |model_name|
       context "when model is #{model_name}" do
         let(:model_name) { model_name }
         it 'should not be visible' do

--- a/spec/config/initializers/rails_admin_spec.rb
+++ b/spec/config/initializers/rails_admin_spec.rb
@@ -1,105 +1,27 @@
 RSpec.describe RailsAdmin.config do
   describe '#included_models' do
     subject { RailsAdmin.config.included_models }
-    it { is_expected.to eq(%w(Banner BrowseEntry Collection DataProvider DataProviderLogo FacetLinkGroup Gallery HeroImage Link Link::Promotion Link::Credit Link::SocialMedia MediaObject Page Page::Error Page::Landing Topic User)) }
+    it { is_expected.to eq(%w(Banner BrowseEntry Categorisation Collection DataProvider DataProviderLogo FacetLinkGroup Gallery HeroImage Link Link::Promotion Link::Credit Link::SocialMedia MediaObject Page Page::Error Page::Landing Topic User)) }
   end
 
   describe '#model' do
     let(:model) { RailsAdmin.config.models.find { |m| m.abstract_model.model_name == model_name } }
 
-    context 'when model is Banner' do
-      let(:model_name) { 'Banner' }
-      describe '.visible' do
-        subject { model.visible }
-        it { is_expected.to be true }
+    %w(Banner BrowseEntry Collection Gallery Page Page::Error Page::Landing Topic User).each do |model_name|
+      context "when model is #{model_name}" do
+        let(:model_name) { model_name }
+        it 'should be visible' do
+          expect(model.visible).to be true
+        end
       end
     end
 
-    context 'when model is BrowseEntry' do
-      let(:model_name) { 'BrowseEntry' }
-      describe '.visible' do
-        subject { model.visible }
-        it { is_expected.to be true }
-      end
-    end
-
-    context 'when model is Collection' do
-      let(:model_name) { 'Collection' }
-      describe '.visible' do
-        subject { model.visible }
-        it { is_expected.to be true }
-      end
-    end
-
-    context 'when model is Gallery' do
-      let(:model_name) { 'Gallery' }
-      describe '.visible' do
-        subject { model.visible }
-        it { is_expected.to be true }
-      end
-    end
-
-    context 'when model is HeroImage' do
-      let(:model_name) { 'HeroImage' }
-      describe '.visible' do
-        subject { model.visible }
-        it { is_expected.to be false }
-      end
-    end
-
-    context 'when model is Link' do
-      let(:model_name) { 'Link' }
-      describe '.visible' do
-        subject { model.visible }
-        it { is_expected.to be false }
-      end
-    end
-
-    context 'when model is MediaObject' do
-      let(:model_name) { 'MediaObject' }
-      describe '.visible' do
-        subject { model.visible }
-        it { is_expected.to be false }
-      end
-    end
-
-    context 'when model is Page' do
-      let(:model_name) { 'Page' }
-      describe '.visible' do
-        subject { model.visible }
-        it { is_expected.to be true }
-      end
-    end
-
-    context 'when model is Page::Error' do
-      let(:model_name) { 'Page::Error' }
-      describe '.visible' do
-        subject { model.visible }
-        it { is_expected.to be true }
-      end
-    end
-
-    context 'when model is Page::Landing' do
-      let(:model_name) { 'Page::Landing' }
-      describe '.visible' do
-        subject { model.visible }
-        it { is_expected.to be true }
-      end
-    end
-
-    context 'when model is Topic' do
-      let(:model_name) { 'Topic' }
-      describe '.visible' do
-        subject { model.visible }
-        it { is_expected.to be true }
-      end
-    end
-
-    context 'when model is User' do
-      let(:model_name) { 'User' }
-      describe '.visible' do
-        subject { model.visible }
-        it { is_expected.to be true }
+    %w(Categorisation HeroImage Link MediaObject).each do |model_name|
+      context "when model is #{model_name}" do
+        let(:model_name) { model_name }
+        it 'should not be visible' do
+          expect(model.visible).to be false
+        end
       end
     end
   end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe Ability do
     it { is_expected.not_to be_able_to(:manage, Page::Landing.new) }
     it { is_expected.not_to be_able_to(:manage, Link.new) }
     it { is_expected.not_to be_able_to(:manage, MediaObject.new) }
+    it { is_expected.not_to be_able_to(:manage, Topic.new) }
     it { is_expected.not_to be_able_to(:manage, User.new) }
 
     it { is_expected.not_to be_able_to(:show, draft_banner) }
@@ -56,6 +57,7 @@ RSpec.describe Ability do
     it { is_expected.not_to be_able_to(:manage, Page::Landing.new) }
     it { is_expected.not_to be_able_to(:manage, Link.new) }
     it { is_expected.not_to be_able_to(:manage, MediaObject.new) }
+    it { is_expected.not_to be_able_to(:manage, Topic.new) }
     it { is_expected.not_to be_able_to(:manage, User.new) }
 
     it { is_expected.not_to be_able_to(:show, draft_banner) }
@@ -83,6 +85,7 @@ RSpec.describe Ability do
     it { is_expected.to be_able_to(:manage, Page::Landing.new) }
     it { is_expected.to be_able_to(:manage, Link.new) }
     it { is_expected.to be_able_to(:manage, MediaObject.new) }
+    it { is_expected.to be_able_to(:manage, Topic.new) }
     it { is_expected.to be_able_to(:manage, User.new) }
 
     it { is_expected.to be_able_to(:show, draft_banner) }

--- a/spec/models/categorisation_spec.rb
+++ b/spec/models/categorisation_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+RSpec.describe Categorisation do
+  it { is_expected.to validate_presence_of(:topic_id) }
+  it { is_expected.to validate_presence_of(:categorisable) }
+  it { is_expected.to belong_to(:topic).inverse_of(:categorisations) }
+  it { is_expected.to belong_to(:categorisable) }
+end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -1,6 +1,5 @@
 RSpec.describe Collection do
   it { is_expected.to have_and_belong_to_many(:browse_entries) }
-  it { is_expected.to have_and_belong_to_many(:galleries).inverse_of(:collections) }
   it { is_expected.to validate_presence_of(:key) }
   it { is_expected.to validate_uniqueness_of(:key) }
   it { is_expected.to validate_presence_of(:api_params) }

--- a/spec/models/gallery_spec.rb
+++ b/spec/models/gallery_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Gallery do
   end
 
   it { is_expected.to have_many(:images).inverse_of(:gallery).dependent(:destroy) }
-  it { is_expected.to have_and_belong_to_many(:collections).inverse_of(:galleries) }
+  it { is_expected.to have_one(:topic).through(:categorisation) }
   it { is_expected.to validate_presence_of(:title) }
   it { is_expected.to validate_length_of(:title).is_at_most(60) }
   it { is_expected.to validate_length_of(:description).is_at_most(280) }
@@ -15,6 +15,10 @@ RSpec.describe Gallery do
 
   it 'should have publication states' do
     expect(described_class).to include(HasPublicationStates)
+  end
+
+  it 'should be categorisable' do
+    expect(described_class).to include(IsCategorisable)
   end
 
   it 'should translate title' do

--- a/spec/models/gallery_spec.rb
+++ b/spec/models/gallery_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Gallery do
   end
 
   it { is_expected.to have_many(:images).inverse_of(:gallery).dependent(:destroy) }
-  it { is_expected.to have_one(:topic).through(:categorisation) }
+  it { is_expected.to have_many(:topics).through(:categorisations) }
   it { is_expected.to validate_presence_of(:title) }
   it { is_expected.to validate_length_of(:title).is_at_most(60) }
   it { is_expected.to validate_length_of(:description).is_at_most(280) }

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+RSpec.describe Topic do
+  it { is_expected.to validate_presence_of(:name) }
+  it { is_expected.to validate_uniqueness_of(:name) }
+  it { is_expected.to validate_uniqueness_of(:entity_uri).allow_blank }
+  it { is_expected.to have_many(:galleries).inverse_of(:gallery).dependent(:destroy) }
+
+  it 'should translate name' do
+    expect(described_class.translated_attribute_names).to include(:name)
+  end
+
+  describe '#to_param' do
+    it 'should return the slug' do
+      topic = Topic.new(name: 'Art history', slug: 'art-history')
+      expect(topic.to_param).to eq('art-history')
+    end
+  end
+end

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -3,10 +3,15 @@ RSpec.describe Topic do
   it { is_expected.to validate_presence_of(:name) }
   it { is_expected.to validate_uniqueness_of(:name) }
   it { is_expected.to validate_uniqueness_of(:entity_uri).allow_blank }
-  it { is_expected.to have_many(:galleries).inverse_of(:gallery).dependent(:destroy) }
+  it { is_expected.to have_many(:categorisations).inverse_of(:topic).dependent(:destroy) }
 
   it 'should translate name' do
     expect(described_class.translated_attribute_names).to include(:name)
+  end
+
+  it 'should set the slug from the name' do
+    topic = Topic.create(name: 'Art history')
+    expect(topic.slug).to eq('art-history')
   end
 
   describe '#to_param' do

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Topic do
   it { is_expected.to have_many(:categorisations).inverse_of(:topic).dependent(:destroy) }
 
   it 'should translate label' do
-    expect(described_class.translated_attribute_labels).to include(:label)
+    expect(described_class.translated_attribute_names).to include(:label)
   end
 
   it 'should set the slug from the label' do

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -1,22 +1,22 @@
 # frozen_string_literal: true
 RSpec.describe Topic do
-  it { is_expected.to validate_presence_of(:name) }
-  it { is_expected.to validate_uniqueness_of(:name) }
+  it { is_expected.to validate_presence_of(:label) }
+  it { is_expected.to validate_uniqueness_of(:label) }
   it { is_expected.to validate_uniqueness_of(:entity_uri).allow_blank }
   it { is_expected.to have_many(:categorisations).inverse_of(:topic).dependent(:destroy) }
 
-  it 'should translate name' do
-    expect(described_class.translated_attribute_names).to include(:name)
+  it 'should translate label' do
+    expect(described_class.translated_attribute_labels).to include(:label)
   end
 
-  it 'should set the slug from the name' do
-    topic = Topic.create(name: 'Art history')
+  it 'should set the slug from the label' do
+    topic = Topic.create(label: 'Art history')
     expect(topic.slug).to eq('art-history')
   end
 
   describe '#to_param' do
     it 'should return the slug' do
-      topic = Topic.new(name: 'Art history', slug: 'art-history')
+      topic = Topic.new(label: 'Art history', slug: 'art-history')
       expect(topic.to_param).to eq('art-history')
     end
   end


### PR DESCRIPTION
Re: https://europeanadev.assembla.com/spaces/europeana-npc/tickets/1905

Using this requires running both `db:migrate` and `db:seed` (latter is non-destructive)

Galleries can be assigned a topic from a pre-seeded list in the CMS.

Topics are associated with galleries, via a polymorphic association on the other new model, Categorisation. The reason for this approach instead of adding a foreign key to the galleries table is that it makes it trivial in future to make other models categorisable using these topics, without adding foreign keys to their tables.

One thing that is not great yet is the way the topic input is presented in the RailsAdmin CMS for a gallery, where it appears as a nested form beneath categorisation. Any ideas on how to improve that, simplifying it to just have the topic select at the same level as the other gallery form fields are most welcome!