### PR TITLE
Gallery foyer pagination

### DIFF
--- a/app/controllers/galleries_controller.rb
+++ b/app/controllers/galleries_controller.rb
@@ -37,10 +37,10 @@ class GalleriesController < ApplicationController
   end
 
   def gallery_page
-    params[:page].to_i || 1
+    (params[:page] || 1).to_i
   end
 
   def gallery_per
-    params[:per_page].to_i || 24
+    (params[:per_page] || 24).to_i
   end
 end

--- a/app/controllers/galleries_controller.rb
+++ b/app/controllers/galleries_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class GalleriesController < ApplicationController
   def index
-    @galleries = Gallery.includes(:images).published
+    @galleries = Gallery.includes(:images).published.page(gallery_page).per(gallery_per)
     @documents = search_api_for_image_metadata(gallery_images_for_foyer(@galleries))
     @hero_image = homepage_hero_image
   end
@@ -34,5 +34,13 @@ class GalleriesController < ApplicationController
   def homepage_hero_image
     landing_page = Page::Landing.find_by_slug('')
     landing_page.nil? ? nil : landing_page.hero_image
+  end
+
+  def gallery_page
+    params[:page].to_i || 1
+  end
+
+  def gallery_per
+    params[:per_page].to_i || 24
   end
 end

--- a/app/views/galleries/index.rb
+++ b/app/views/galleries/index.rb
@@ -25,7 +25,38 @@ module Galleries
       end
     end
 
+    def navigation
+      {
+        pagination: {
+          prev_url: prev_page.url,
+          next_url: next_page.url,
+          is_first_page: @galleries.first_page?,
+          is_last_page: @galleries.last_page?,
+          pages: navigation_pagination_pages
+        }
+      }.reverse_merge(super)
+    end
+
     private
+
+    def navigation_pagination_pages
+      (1..@galleries.total_pages).map do |number|
+        page = Kaminari::Helpers::Page.new(self, page: number)
+        {
+          url: page.url,
+          index: number,
+          is_current: number == @galleries.current_page
+        }
+      end
+    end
+
+    def prev_page
+      @prev_page ||= Kaminari::Helpers::PrevPage.new(self, current_page: @galleries.current_page)
+    end
+
+    def next_page
+      @next_page ||= Kaminari::Helpers::NextPage.new(self, current_page: @galleries.current_page)
+    end
 
     def hero_content
       {

--- a/spec/controllers/galleries_controller_spec.rb
+++ b/spec/controllers/galleries_controller_spec.rb
@@ -8,8 +8,10 @@ RSpec.describe GalleriesController do
 
     it 'assigns published galleries to @galleries' do
       get :index, locale: 'en'
-      expect(assigns[:galleries]).to eq(Gallery.published)
-      expect(assigns[:galleries]).not_to include(galleries(:draft))
+      expect(assigns[:galleries]).not_to be_blank
+      assigns[:galleries].each do |gallery|
+        expect(gallery).to be_published
+      end
     end
 
     it 'searches the API for the gallery image metadata' do

--- a/spec/controllers/galleries_controller_spec.rb
+++ b/spec/controllers/galleries_controller_spec.rb
@@ -14,6 +14,18 @@ RSpec.describe GalleriesController do
       end
     end
 
+    it 'paginates galleries' do
+      galleries = (1..30).each do |gallery_num|
+        urls = (1..6).map { |image_num| "http://www.europeana.eu/portal/record/#{gallery_num}/#{image_num}.html" }.join(' ')
+        Gallery.create!(title: "Gallery #{gallery_num}", image_portal_urls: urls).tap do |gallery|
+          gallery.publish!
+        end
+      end
+
+      get :index, locale: 'en'
+      expect(assigns[:galleries].length).to eq(24)
+    end
+
     it 'searches the API for the gallery image metadata' do
       get :index, locale: 'en'
       ids = Gallery.published.map(&:images).flatten.map(&:europeana_record_id)

--- a/spec/controllers/galleries_controller_spec.rb
+++ b/spec/controllers/galleries_controller_spec.rb
@@ -15,11 +15,9 @@ RSpec.describe GalleriesController do
     end
 
     it 'paginates galleries' do
-      galleries = (1..30).each do |gallery_num|
+      (1..30).each do |gallery_num|
         urls = (1..6).map { |image_num| "http://www.europeana.eu/portal/record/#{gallery_num}/#{image_num}.html" }.join(' ')
-        Gallery.create!(title: "Gallery #{gallery_num}", image_portal_urls: urls).tap do |gallery|
-          gallery.publish!
-        end
+        Gallery.create!(title: "Gallery #{gallery_num}", image_portal_urls: urls).publish!
       end
 
       get :index, locale: 'en'


### PR DESCRIPTION
A default of 24 galleries are shown per page. This can be overriden via the `per_page` URL param, which will facilitate testing.