### PR TITLE
Make hierarchies API request before similar items

### DIFF
--- a/app/controllers/portal_controller.rb
+++ b/app/controllers/portal_controller.rb
@@ -48,8 +48,12 @@ class PortalController < ApplicationController
     @url_conversions = perform_url_conversions(@document)
     @oembed_html = oembed_for_urls(@document, @url_conversions)
 
-    @mlt_response, @similar = more_like_this(@document, nil, per_page: 4)
     @hierarchy = document_hierarchy(@document)
+    if @hierarchy.nil?
+      @mlt_response, @similar = more_like_this(@document, nil, per_page: 4)
+    else
+      @mlt_response, @similar = [nil, []]
+    end
     @annotations = document_annotations(@document)
 
     @debug = JSON.pretty_generate(@document.as_json.merge(hierarchy: @hierarchy.as_json)) if params[:debug] == 'json'

--- a/app/controllers/portal_controller.rb
+++ b/app/controllers/portal_controller.rb
@@ -52,7 +52,8 @@ class PortalController < ApplicationController
     if @hierarchy.nil?
       @mlt_response, @similar = more_like_this(@document, nil, per_page: 4)
     else
-      @mlt_response, @similar = [nil, []]
+      @mlt_response = nil
+      @similar = []
     end
     @annotations = document_annotations(@document)
 


### PR DESCRIPTION
Because similar items are never displayed if a hierarchy is present.