### PR TITLE
Remove categorisable presence validation

### DIFF
--- a/app/models/categorisation.rb
+++ b/app/models/categorisation.rb
@@ -4,7 +4,6 @@ class Categorisation < ActiveRecord::Base
   belongs_to :topic, inverse_of: :categorisations
 
   validates :topic_id, presence: true
-  validates :categorisable, presence: true
 
   default_scope { includes(:topic) }
 

--- a/spec/models/categorisation_spec.rb
+++ b/spec/models/categorisation_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 RSpec.describe Categorisation do
   it { is_expected.to validate_presence_of(:topic_id) }
-  it { is_expected.to validate_presence_of(:categorisable) }
   it { is_expected.to belong_to(:topic).inverse_of(:categorisations) }
   it { is_expected.to belong_to(:categorisable) }
 end


### PR DESCRIPTION
Else validation on categorisable objects fails if they are new records.