### PR TITLE
add newsletter_url to landing pages

### DIFF
--- a/app/views/collections/show.rb
+++ b/app/views/collections/show.rb
@@ -106,10 +106,10 @@ module Collections
     private
 
     def newsletter_content
-      return nil unless @collection.newsletter_url.present?
+      return nil unless @landing_page.newsletter_url.present?
       {
         form: {
-          action: @collection.newsletter_url,
+          action: @landing_page.newsletter_url,
           language_op: false,
           placeholder: t('global.email-address')
         },

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -122,14 +122,12 @@ RailsAdmin.config do |config|
       field :state
       field :api_params
       field :settings_default_search_layout, :enum
-      field :newsletter_url
     end
     edit do
       field :key
       field :title
       field :api_params
       field :settings_default_search_layout, :enum
-      field :newsletter_url
     end
   end
 
@@ -414,6 +412,7 @@ RailsAdmin.config do |config|
       field :browse_entries
       field :facet_link_groups
       field :banner
+      field :newsletter_url
     end
     edit do
       field :slug
@@ -439,6 +438,7 @@ RailsAdmin.config do |config|
         end
       end
       field :banner
+      field :newsletter_url
     end
   end
 

--- a/config/locales/rails.en.yml
+++ b/config/locales/rails.en.yml
@@ -3,7 +3,6 @@ en:
     attributes:
       collection:
         api_params: API parameters
-        newsletter_url: Newsletter URL
         settings_default_search_layout: Default search layout
       data_provider:
         uri: URI
@@ -36,5 +35,6 @@ en:
         one: Error Page
         other: Error Pages
       page/landing:
+        newsletter_url: Newsletter URL
         one: Landing Page
         other: Landing Pages

--- a/db/migrate/20170220131250_add_newsletter_url_to_page.rb
+++ b/db/migrate/20170220131250_add_newsletter_url_to_page.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+class AddNewsletterUrlToPage < ActiveRecord::Migration
+  def change
+    add_column :pages, :newsletter_url, :string
+
+    reversible do |dir|
+      dir.up do
+        if fashion = Page::Landing.find_by_slug('collections/fashion')
+          fashion.update_attributes(newsletter_url: 'http://europeanafashion.us5.list-manage.com/subscribe?u=08acbb4918e78ab1b8b1cb158&id=eeaec60e70')
+        end
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170213115802) do
+ActiveRecord::Schema.define(version: 20170220131250) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -169,9 +169,9 @@ ActiveRecord::Schema.define(version: 20170213115802) do
   end
 
   create_table "galleries", force: :cascade do |t|
-    t.integer  "state",      default: 0
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
+    t.integer  "state",        default: 0
+    t.datetime "created_at",               null: false
+    t.datetime "updated_at",               null: false
     t.text     "slug"
     t.datetime "published_at"
     t.integer  "published_by"
@@ -278,15 +278,16 @@ ActiveRecord::Schema.define(version: 20170213115802) do
 
   create_table "pages", force: :cascade do |t|
     t.integer  "hero_image_id"
-    t.string   "slug",          limit: 255
-    t.integer  "state",                     default: 0
-    t.string   "type",          limit: 255
+    t.string   "slug",           limit: 255
+    t.integer  "state",                      default: 0
+    t.string   "type",           limit: 255
     t.integer  "http_code"
-    t.datetime "created_at",                            null: false
-    t.datetime "updated_at",                            null: false
+    t.datetime "created_at",                             null: false
+    t.datetime "updated_at",                             null: false
     t.integer  "banner_id"
     t.text     "settings"
     t.string   "strapline"
+    t.string   "newsletter_url"
   end
 
   add_index "pages", ["banner_id"], name: "index_pages_on_banner_id", using: :btree

--- a/db/seeds/collections.rb
+++ b/db/seeds/collections.rb
@@ -58,8 +58,7 @@ unless Collection.find_by_key('fashion').present?
     Collection.create!(
       key: 'fashion',
       title: 'Fashion',
-      api_params: 'qf=(PROVIDER: "Europeana Fashion")',
-      newsletter_url: 'http://europeanafashion.us5.list-manage.com/subscribe?u=08acbb4918e78ab1b8b1cb158&id=eeaec60e70'
+      api_params: 'qf=(PROVIDER: "Europeana Fashion")'
     ).publish!
   end
 end

--- a/db/seeds/landing_pages.rb
+++ b/db/seeds/landing_pages.rb
@@ -274,3 +274,57 @@ unless Page::Landing.find_by_slug('collections/music').present?
     music_landing.publish!
   end
 end
+
+unless Page::Landing.find_by_slug('collections/fashion').present?
+  ActiveRecord::Base.transaction do
+    fashion_landing = Page::Landing.create!(
+        slug: 'collections/fashion',
+        title: 'Europeana Fashion',
+        strapline: 'Discover %{total_item_count} historical dresses, accessories and catwalk photographs from across Europe.',
+        body: '<b>Europeana Fashion</b> brings together more than 30 public and private archives and museums from across Europe in order give public access to high quality digital fashion content, ranging from historical dresses to accessories, catwalk photographs, drawings, sketches, videos, and fashion catalogues. Records ranging from historical dresses to accessoires, catwalk photographs, drawings, sketches, video\'s and fashion catalogues.',
+        credits: [
+            Link::Credit.new(url: 'http://www.europeanafashion.eu/portal/about.html', text: 'About Europeana Fashion')
+        ],
+        social_media: [
+            Link::SocialMedia.new(url: 'http://www.twitter.com/europeanafashion', text: 'Twitter'),
+            Link::SocialMedia.new(url: 'https://www.facebook.com/EuropeanaFashion', text: 'Facebook'),
+            Link::SocialMedia.new(url: 'https://plus.google.com/115879951963722227275/posts', text: 'Google Plus'),
+            Link::SocialMedia.new(url: 'http://instagram.com/europeanafashionofficial', text: 'Instagram'),
+            Link::SocialMedia.new(url: 'hhttp://www.pinterest.com/eurfashion/', text: 'Pinterest'),
+            Link::SocialMedia.new(url: 'http://europeanafashion.tumblr.com/', text: 'Tumblr'),
+            Link::SocialMedia.new(url: 'https://nl.linkedin.com/company/europeana', text: 'Linkedin')
+        ],
+        promotions: [
+            Link::Promotion.new(
+                position: 0,
+                url: 'http://www.europeanafashion.eu/portal/themedetail.html#11',
+                text: 'Prints!',
+                settings_category: 'exhibition',
+                media_object: find_or_download_styleguide_image('sample/thumb-instruments.jpg')
+            ),
+            Link::Promotion.new(
+                position: 1,
+                url: 'http://www.europeanafashion.eu/portal/themedetail.html#26',
+                text: 'Monochromes',
+                settings_category: 'exhibition',
+                media_object: find_or_download_styleguide_image('sample/thumb-wedding.jpg')
+            ),
+            Link::Promotion.new(
+                position: 2,
+                url: 'http://www.europeanafashion.eu/portal/themedetail.html#15',
+                text: 'Recording and playing Machines',
+                settings_category: 'exhibition',
+                media_object: find_or_download_styleguide_image('sample/thumb-machines.jpg')
+            ),
+            Link::Promotion.new(
+                position: 3,
+                url: 'http://www.europeanafashion.eu/portal/themedetail.html#21',
+                text: 'Sportswear',
+                settings_category: 'exhibition',
+                media_object: find_or_download_styleguide_image('sample/thumb-machines.jpg')
+            )
+        ]
+    )
+    fashion_landing.publish!
+  end
+end

--- a/db/seeds/landing_pages.rb
+++ b/db/seeds/landing_pages.rb
@@ -290,7 +290,7 @@ unless Page::Landing.find_by_slug('collections/fashion').present?
         Link::SocialMedia.new(url: 'https://www.facebook.com/EuropeanaFashion', text: 'Facebook'),
         Link::SocialMedia.new(url: 'https://plus.google.com/115879951963722227275/posts', text: 'Google Plus'),
         Link::SocialMedia.new(url: 'http://instagram.com/europeanafashionofficial', text: 'Instagram'),
-        Link::SocialMedia.new(url: 'hhttp://www.pinterest.com/eurfashion/', text: 'Pinterest'),
+        Link::SocialMedia.new(url: 'http://www.pinterest.com/eurfashion/', text: 'Pinterest'),
         Link::SocialMedia.new(url: 'http://europeanafashion.tumblr.com/', text: 'Tumblr'),
         Link::SocialMedia.new(url: 'https://nl.linkedin.com/company/europeana', text: 'Linkedin')
       ],

--- a/db/seeds/landing_pages.rb
+++ b/db/seeds/landing_pages.rb
@@ -278,52 +278,52 @@ end
 unless Page::Landing.find_by_slug('collections/fashion').present?
   ActiveRecord::Base.transaction do
     fashion_landing = Page::Landing.create!(
-        slug: 'collections/fashion',
-        title: 'Europeana Fashion',
-        strapline: 'Discover %{total_item_count} historical dresses, accessories and catwalk photographs from across Europe.',
-        body: '<b>Europeana Fashion</b> brings together more than 30 public and private archives and museums from across Europe in order give public access to high quality digital fashion content, ranging from historical dresses to accessories, catwalk photographs, drawings, sketches, videos, and fashion catalogues. Records ranging from historical dresses to accessoires, catwalk photographs, drawings, sketches, video\'s and fashion catalogues.',
-        credits: [
-            Link::Credit.new(url: 'http://www.europeanafashion.eu/portal/about.html', text: 'About Europeana Fashion')
-        ],
-        social_media: [
-            Link::SocialMedia.new(url: 'http://www.twitter.com/europeanafashion', text: 'Twitter'),
-            Link::SocialMedia.new(url: 'https://www.facebook.com/EuropeanaFashion', text: 'Facebook'),
-            Link::SocialMedia.new(url: 'https://plus.google.com/115879951963722227275/posts', text: 'Google Plus'),
-            Link::SocialMedia.new(url: 'http://instagram.com/europeanafashionofficial', text: 'Instagram'),
-            Link::SocialMedia.new(url: 'hhttp://www.pinterest.com/eurfashion/', text: 'Pinterest'),
-            Link::SocialMedia.new(url: 'http://europeanafashion.tumblr.com/', text: 'Tumblr'),
-            Link::SocialMedia.new(url: 'https://nl.linkedin.com/company/europeana', text: 'Linkedin')
-        ],
-        promotions: [
-            Link::Promotion.new(
-                position: 0,
-                url: 'http://www.europeanafashion.eu/portal/themedetail.html#11',
-                text: 'Prints!',
-                settings_category: 'exhibition',
-                media_object: find_or_download_styleguide_image('sample/thumb-instruments.jpg')
-            ),
-            Link::Promotion.new(
-                position: 1,
-                url: 'http://www.europeanafashion.eu/portal/themedetail.html#26',
-                text: 'Monochromes',
-                settings_category: 'exhibition',
-                media_object: find_or_download_styleguide_image('sample/thumb-wedding.jpg')
-            ),
-            Link::Promotion.new(
-                position: 2,
-                url: 'http://www.europeanafashion.eu/portal/themedetail.html#15',
-                text: 'Recording and playing Machines',
-                settings_category: 'exhibition',
-                media_object: find_or_download_styleguide_image('sample/thumb-machines.jpg')
-            ),
-            Link::Promotion.new(
-                position: 3,
-                url: 'http://www.europeanafashion.eu/portal/themedetail.html#21',
-                text: 'Sportswear',
-                settings_category: 'exhibition',
-                media_object: find_or_download_styleguide_image('sample/thumb-machines.jpg')
-            )
-        ]
+      slug: 'collections/fashion',
+      title: 'Europeana Fashion',
+      strapline: 'Discover %{total_item_count} historical dresses, accessories and catwalk photographs from across Europe.',
+      body: '<b>Europeana Fashion</b> brings together more than 30 public and private archives and museums from across Europe in order give public access to high quality digital fashion content, ranging from historical dresses to accessories, catwalk photographs, drawings, sketches, videos, and fashion catalogues. Records ranging from historical dresses to accessoires, catwalk photographs, drawings, sketches, video\'s and fashion catalogues.',
+      credits: [
+        Link::Credit.new(url: 'http://www.europeanafashion.eu/portal/about.html', text: 'About Europeana Fashion')
+      ],
+      social_media: [
+        Link::SocialMedia.new(url: 'http://www.twitter.com/europeanafashion', text: 'Twitter'),
+        Link::SocialMedia.new(url: 'https://www.facebook.com/EuropeanaFashion', text: 'Facebook'),
+        Link::SocialMedia.new(url: 'https://plus.google.com/115879951963722227275/posts', text: 'Google Plus'),
+        Link::SocialMedia.new(url: 'http://instagram.com/europeanafashionofficial', text: 'Instagram'),
+        Link::SocialMedia.new(url: 'hhttp://www.pinterest.com/eurfashion/', text: 'Pinterest'),
+        Link::SocialMedia.new(url: 'http://europeanafashion.tumblr.com/', text: 'Tumblr'),
+        Link::SocialMedia.new(url: 'https://nl.linkedin.com/company/europeana', text: 'Linkedin')
+      ],
+      promotions: [
+        Link::Promotion.new(
+          position: 0,
+          url: 'http://www.europeanafashion.eu/portal/themedetail.html#11',
+          text: 'Prints!',
+          settings_category: 'exhibition',
+          media_object: find_or_download_styleguide_image('sample/thumb-instruments.jpg')
+        ),
+        Link::Promotion.new(
+          position: 1,
+          url: 'http://www.europeanafashion.eu/portal/themedetail.html#26',
+          text: 'Monochromes',
+          settings_category: 'exhibition',
+          media_object: find_or_download_styleguide_image('sample/thumb-wedding.jpg')
+        ),
+        Link::Promotion.new(
+          position: 2,
+          url: 'http://www.europeanafashion.eu/portal/themedetail.html#15',
+          text: 'Recording and playing Machines',
+          settings_category: 'exhibition',
+          media_object: find_or_download_styleguide_image('sample/thumb-machines.jpg')
+        ),
+        Link::Promotion.new(
+          position: 3,
+          url: 'http://www.europeanafashion.eu/portal/themedetail.html#21',
+          text: 'Sportswear',
+          settings_category: 'exhibition',
+          media_object: find_or_download_styleguide_image('sample/thumb-machines.jpg')
+        )
+      ]
     )
     fashion_landing.publish!
   end

--- a/spec/fixtures/pages.yml
+++ b/spec/fixtures/pages.yml
@@ -34,6 +34,7 @@ fashion_collection:
   slug: 'collections/fashion'
   state: 1
   type: 'Page::Landing'
+  newsletter_url: 'http://europeanafashion.us5.list-manage.com/subscribe?u=08acbb4918e78ab1b8b1cb158&id=eeaec60e70'
 
 grid_layout_collection:
   slug: 'collections/grid_layout'

--- a/spec/models/page/landing_spec.rb
+++ b/spec/models/page/landing_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe Page::Landing do
   it { is_expected.to accept_nested_attributes_for(:promotions) }
   it { is_expected.to accept_nested_attributes_for(:browse_entries) }
 
+  it { is_expected.to respond_to(:newsletter_url) }
+
   it { is_expected.to delegate_method(:file).to(:hero_image).with_prefix(true) }
 
   it { is_expected.to validate_inclusion_of(:settings_layout_type).in_array(%w(default browse)) }


### PR DESCRIPTION
This adds a newsletter_url column to the pages table and uses it instead of the one from the collections table.
Removal of the collections table's column should happen separately, and after these changes have been released.