### PR TITLE
Allow deletion of X-Frame-Options response header

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,10 @@
 
 # 2. Optional environment variables
 
+## Delete X-Frame-Options header from all responses, to permit embedding in
+## remote iframes, overriding Rails 4's default value of SAMEORIGIN.
+# DELETE_X_FRAME_OPTIONS_RESPONSE_HEADER=1
+
 ## Disable view caching, forcing Rails to re-render any pages that might
 ## otherwise be cached. Useful during development.
 # DISABLE_VIEW_CACHING=1

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,7 +12,7 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
-  before_action :set_locale
+  before_action :set_locale, :permit_iframing
 
   layout proc { kind_of?(Europeana::Styleguide) ? false : 'application' }
 
@@ -33,6 +33,10 @@ class ApplicationController < ActionController::Base
     end
 
     I18n.locale = session[:locale]
+  end
+
+  def permit_iframing
+    response.headers.delete('X-Frame-Options') if ENV['DELETE_X_FRAME_OPTIONS_RESPONSE_HEADER']
   end
 
   def extract_locale_from_accept_language_header


### PR DESCRIPTION
By setting env var `DELETE_X_FRAME_OPTIONS_RESPONSE_HEADER=1`