### PR TITLE
update the gallery image limit to 48

### DIFF
--- a/app/models/gallery.rb
+++ b/app/models/gallery.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class Gallery < ActiveRecord::Base
-  NUMBER_OF_IMAGES = 6..24
+  NUMBER_OF_IMAGES = 6..48
 
   include HasPublicationStates
   include IsCategorisable

--- a/spec/models/gallery_spec.rb
+++ b/spec/models/gallery_spec.rb
@@ -183,11 +183,11 @@ RSpec.describe Gallery do
     expect(gallery.errors[:image_portal_urls]).not_to be_none
   end
 
-  it 'should require 6-24 images' do
+  it 'should require 6-48 images' do
     gallery = galleries(:empty)
-    (1..30).each do |number|
+    (1..50).each do |number|
       gallery.image_portal_urls = gallery_image_portal_urls(number: number)
-      if number < 6 || number > 24
+      if number < 6 || number > 48
         expect(gallery).not_to be_valid
         expect(gallery.errors[:image_portal_urls]).not_to be_none
       else


### PR DESCRIPTION
Increase the galley image count limit to 48 in accordance with https://europeanadev.assembla.com/spaces/europeana-npc/tickets/1987-up-the-amount-of-maximum-images-in-the-gallery/details#