### PR TITLE
Re: #1978 connect collections and landing pages

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -4,7 +4,7 @@ class Collection < ActiveRecord::Base
   include HasSettingsAttribute
 
   has_and_belongs_to_many :browse_entries
-  has_one :page_landing, class_name:'Page::Landing', dependent: :destroy
+  has_one :page_landing, class_name: 'Page::Landing', dependent: :destroy
 
   has_paper_trail
 

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -4,7 +4,7 @@ class Collection < ActiveRecord::Base
   include HasSettingsAttribute
 
   has_and_belongs_to_many :browse_entries
-  has_one :page_landing, class_name: 'Page::Landing', dependent: :destroy
+  has_one :landing_page, class_name: 'Page::Landing', dependent: :destroy
 
   has_paper_trail
 
@@ -43,10 +43,6 @@ class Collection < ActiveRecord::Base
 
   def has_landing_page?
     landing_page.present?
-  end
-
-  def landing_page
-    @landing_page ||= page_landing
   end
 
   def landing_page_title

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -4,6 +4,7 @@ class Collection < ActiveRecord::Base
   include HasSettingsAttribute
 
   has_and_belongs_to_many :browse_entries
+  has_one :page_landing, :class_name => 'Page::Landing', dependent: :destroy
 
   has_paper_trail
 
@@ -45,11 +46,7 @@ class Collection < ActiveRecord::Base
   end
 
   def landing_page
-    @landing_page ||= Page::Landing.find_by_slug(landing_page_slug)
-  end
-
-  def landing_page_slug
-    key == 'all' ? '' : "collections/#{key}"
+    @landing_page ||= page_landing
   end
 
   def landing_page_title

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -4,7 +4,7 @@ class Collection < ActiveRecord::Base
   include HasSettingsAttribute
 
   has_and_belongs_to_many :browse_entries
-  has_one :page_landing, :class_name => 'Page::Landing', dependent: :destroy
+  has_one :page_landing, class_name:'Page::Landing', dependent: :destroy
 
   has_paper_trail
 

--- a/app/models/page/landing.rb
+++ b/app/models/page/landing.rb
@@ -1,4 +1,5 @@
 class Page::Landing < Page
+  belongs_to :collection
   has_many :credits, -> { order(:position) }, as: :linkable, class_name: 'Link::Credit', dependent: :destroy
   has_many :social_media, -> { order(:position) }, as: :linkable, class_name: 'Link::SocialMedia', dependent: :destroy
   has_many :promotions, -> { order(:position) }, as: :linkable, class_name: 'Link::Promotion', dependent: :destroy
@@ -17,8 +18,11 @@ class Page::Landing < Page
   has_settings :layout_type
 
   validates :settings_layout_type, inclusion: { in: :settings_layout_type_enum }
+  validates :collection, presence: true, uniqueness: true
 
   delegate :settings_layout_type_enum, to: :class
+
+  before_create :set_slug
 
   class << self
     def settings_layout_type_enum
@@ -28,5 +32,14 @@ class Page::Landing < Page
 
   def settings_layout_type
     settings[:layout_type] ? settings[:layout_type] : 'default'
+  end
+
+  private
+
+  def set_slug
+    if collection
+      new_slug = collection.key == 'all' ? '' : "collections/#{collection.key}"
+      self.slug = new_slug
+    end
   end
 end

--- a/app/models/page/landing.rb
+++ b/app/models/page/landing.rb
@@ -1,43 +1,46 @@
-class Page::Landing < Page
-  belongs_to :collection
-  has_many :credits, -> { order(:position) }, as: :linkable, class_name: 'Link::Credit', dependent: :destroy
-  has_many :social_media, -> { order(:position) }, as: :linkable, class_name: 'Link::SocialMedia', dependent: :destroy
-  has_many :promotions, -> { order(:position) }, as: :linkable, class_name: 'Link::Promotion', dependent: :destroy
-  has_many :facet_entries, through: :facet_link_groups, source: :browse_entry_facet_entries
-  has_many :facet_link_groups, class_name: 'FacetLinkGroup', foreign_key: :page_id, dependent: :destroy
+# frozen_string_literal: true
+class Page
+  class Landing < Page
+    belongs_to :collection
+    has_many :credits, -> { order(:position) }, as: :linkable, class_name: 'Link::Credit', dependent: :destroy
+    has_many :social_media, -> { order(:position) }, as: :linkable, class_name: 'Link::SocialMedia', dependent: :destroy
+    has_many :promotions, -> { order(:position) }, as: :linkable, class_name: 'Link::Promotion', dependent: :destroy
+    has_many :facet_entries, through: :facet_link_groups, source: :browse_entry_facet_entries
+    has_many :facet_link_groups, class_name: 'FacetLinkGroup', foreign_key: :page_id, dependent: :destroy
 
-  accepts_nested_attributes_for :facet_link_groups, allow_destroy: true
-  accepts_nested_attributes_for :credits, allow_destroy: true
-  accepts_nested_attributes_for :social_media, allow_destroy: true
-  accepts_nested_attributes_for :promotions, allow_destroy: true
+    accepts_nested_attributes_for :facet_link_groups, allow_destroy: true
+    accepts_nested_attributes_for :credits, allow_destroy: true
+    accepts_nested_attributes_for :social_media, allow_destroy: true
+    accepts_nested_attributes_for :promotions, allow_destroy: true
 
-  translates :title, :body, fallbacks_for_empty_translations: true
-  accepts_nested_attributes_for :translations, allow_destroy: true
-  default_scope { includes(:translations) }
+    translates :title, :body, fallbacks_for_empty_translations: true
+    accepts_nested_attributes_for :translations, allow_destroy: true
+    default_scope { includes(:translations) }
 
-  has_settings :layout_type
+    has_settings :layout_type
 
-  validates :settings_layout_type, inclusion: { in: :settings_layout_type_enum }
-  validates :collection, presence: true, uniqueness: true
+    validates :settings_layout_type, inclusion: { in: :settings_layout_type_enum }
+    validates :collection, presence: true, uniqueness: true
 
-  delegate :settings_layout_type_enum, to: :class
+    delegate :settings_layout_type_enum, to: :class
 
-  before_create :set_slug if :collection
+    before_create :set_slug, if: :collection
 
-  class << self
-    def settings_layout_type_enum
-      %w(default browse)
+    class << self
+      def settings_layout_type_enum
+        %w(default browse)
+      end
     end
-  end
 
-  def settings_layout_type
-    settings[:layout_type] ? settings[:layout_type] : 'default'
-  end
+    def settings_layout_type
+      settings[:layout_type] ? settings[:layout_type] : 'default'
+    end
 
-  private
+    private
 
-  def set_slug
-    new_slug = collection.key == 'all' ? '' : "collections/#{collection.key}"
-    self.slug = new_slug
+    def set_slug
+      new_slug = collection.key == 'all' ? '' : "collections/#{collection.key}"
+      self.slug = new_slug
+    end
   end
 end

--- a/app/models/page/landing.rb
+++ b/app/models/page/landing.rb
@@ -22,7 +22,7 @@ class Page::Landing < Page
 
   delegate :settings_layout_type_enum, to: :class
 
-  before_create :set_slug
+  before_create :set_slug if :collection
 
   class << self
     def settings_layout_type_enum
@@ -37,9 +37,7 @@ class Page::Landing < Page
   private
 
   def set_slug
-    if collection
-      new_slug = collection.key == 'all' ? '' : "collections/#{collection.key}"
-      self.slug = new_slug
-    end
+    new_slug = collection.key == 'all' ? '' : "collections/#{collection.key}"
+    self.slug = new_slug
   end
 end

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -124,7 +124,11 @@ RailsAdmin.config do |config|
       field :settings_default_search_layout, :enum
     end
     edit do
-      field :key
+      field :key do
+        visible do
+          true unless bindings[:object].persisted?
+        end
+      end
       field :title
       field :api_params
       field :settings_default_search_layout, :enum
@@ -408,12 +412,14 @@ RailsAdmin.config do |config|
   config.model 'Page::Landing' do
     object_label_method :title
     list do
+      field :collection
       field :slug
       field :title
       field :hero_image_file, :paperclip
       field :state
     end
     show do
+      field :collection
       field :slug
       field :title do
         searchable 'page_translations.title'
@@ -433,7 +439,14 @@ RailsAdmin.config do |config|
       field :feeds
     end
     edit do
-      field :slug
+      field :collection do
+        visible do
+          true unless bindings[:object].persisted?
+        end
+        associated_collection_scope do
+          proc { |_scope| Collection.published.includes(:page_landing).where(pages: { collection_id: nil }) }
+        end
+      end
       field :title
       field :settings_layout_type, :enum
       field :body, :text do

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -444,7 +444,9 @@ RailsAdmin.config do |config|
           true unless bindings[:object].persisted?
         end
         associated_collection_scope do
-          proc { |_scope| Collection.published.includes(:page_landing).where(pages: { collection_id: nil }) }
+          proc do |_scope|
+            Collection.published.includes(:landing_page).where(pages: { collection_id: nil })
+          end
         end
       end
       field :title

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -444,8 +444,8 @@ RailsAdmin.config do |config|
           true unless bindings[:object].persisted?
         end
         associated_collection_scope do
-          proc do |_scope|
-            Collection.published.includes(:landing_page).where(pages: { collection_id: nil })
+          proc do |scope|
+            scope.published.includes(:landing_page).where(pages: { collection_id: nil })
           end
         end
       end

--- a/db/migrate/20170307114233_add_collection_to_pages.rb
+++ b/db/migrate/20170307114233_add_collection_to_pages.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class AddCollectionToPages < ActiveRecord::Migration
   def change
     add_reference :pages, :collection, index: true

--- a/db/migrate/20170307114233_add_collection_to_pages.rb
+++ b/db/migrate/20170307114233_add_collection_to_pages.rb
@@ -10,8 +10,10 @@ class AddCollectionToPages < ActiveRecord::Migration
           key = landing_page.slug.split('/').last
           key = key.blank? ? 'all' : key
           collection = Collection.find_by_key(key)
-          landing_page.collection = collection
-          landing_page.save
+          if collection
+            landing_page.collection = collection
+            landing_page.save
+          end
         end
       end
     end

--- a/db/migrate/20170307114233_add_collection_to_pages.rb
+++ b/db/migrate/20170307114233_add_collection_to_pages.rb
@@ -1,0 +1,18 @@
+class AddCollectionToPages < ActiveRecord::Migration
+  def change
+    add_reference :pages, :collection, index: true
+    add_foreign_key :pages, :collections
+
+    reversible do |change|
+      change.up do
+        Page::Landing.all.each do |landing_page|
+          key = landing_page.slug.split('/').last
+          key = key.blank? ? 'all' : key
+          collection = Collection.find_by_key(key)
+          landing_page.collection = collection
+          landing_page.save
+        end
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170306134928) do
+ActiveRecord::Schema.define(version: 20170307114233) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -297,9 +297,11 @@ ActiveRecord::Schema.define(version: 20170306134928) do
     t.text     "settings"
     t.string   "strapline"
     t.string   "newsletter_url"
+    t.integer  "collection_id"
   end
 
   add_index "pages", ["banner_id"], name: "index_pages_on_banner_id", using: :btree
+  add_index "pages", ["collection_id"], name: "index_pages_on_collection_id", using: :btree
   add_index "pages", ["hero_image_id"], name: "index_pages_on_hero_image_id", using: :btree
   add_index "pages", ["http_code"], name: "index_pages_on_http_code", using: :btree
   add_index "pages", ["slug"], name: "index_pages_on_slug", using: :btree
@@ -387,4 +389,5 @@ ActiveRecord::Schema.define(version: 20170306134928) do
   add_foreign_key "gallery_images", "galleries"
   add_foreign_key "page_elements", "pages"
   add_foreign_key "pages", "banners"
+  add_foreign_key "pages", "collections"
 end

--- a/spec/fixtures/collections.yml
+++ b/spec/fixtures/collections.yml
@@ -23,6 +23,11 @@ draft:
   api_params: 'qf=what:ever'
   state: 0
 
+internal:
+  key: 'internal'
+  api_params: 'qf=what:ever'
+  state: 0
+
 grid_layout:
   key: 'grid_layout'
   api_params: 'qf=grid'

--- a/spec/fixtures/pages.yml
+++ b/spec/fixtures/pages.yml
@@ -52,6 +52,7 @@ grid_layout_collection:
   type: 'Page::Landing'
 
 draft_landing_page:
+  collection: draft
   state: 0
   type: 'Page::Landing'
 

--- a/spec/fixtures/pages.yml
+++ b/spec/fixtures/pages.yml
@@ -19,6 +19,7 @@ home:
   state: 1
   strapline: '%{total_item_count} items'
   type: 'Page::Landing'
+  collection: all
   feeds:
     - all_blog
 
@@ -26,14 +27,17 @@ music_collection:
   slug: 'collections/music'
   state: 1
   type: 'Page::Landing'
+  collection: music
 
 art_collection:
   slug: 'collections/art'
   state: 0
   type: 'Page::Landing'
+  collection: art
 
 fashion_collection:
   slug: 'collections/fashion'
+  collection: fashion
   state: 1
   type: 'Page::Landing'
   newsletter_url: 'http://europeanafashion.us5.list-manage.com/subscribe?u=08acbb4918e78ab1b8b1cb158&id=eeaec60e70'
@@ -43,11 +47,11 @@ fashion_collection:
 
 grid_layout_collection:
   slug: 'collections/grid_layout'
+  collection: grid_layout
   state: 1
   type: 'Page::Landing'
 
 draft_landing_page:
-  slug: 'draft'
   state: 0
   type: 'Page::Landing'
 

--- a/spec/jobs/cache/record_counts_job_spec.rb
+++ b/spec/jobs/cache/record_counts_job_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Cache::RecordCountsJob do
     it_behaves_like 'record count caching job'
 
     it 'should touch the landing page' do
-      expect { subject.perform(*args) }.to change { collection.landing_page.reload.updated_at }
+      expect { subject.perform(*args) }.to change { collection.page_landing.reload.updated_at }
     end
   end
 

--- a/spec/jobs/cache/record_counts_job_spec.rb
+++ b/spec/jobs/cache/record_counts_job_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Cache::RecordCountsJob do
     it_behaves_like 'record count caching job'
 
     it 'should touch the landing page' do
-      expect { subject.perform(*args) }.to change { collection.page_landing.reload.updated_at }
+      expect { subject.perform(*args) }.to change { collection.landing_page.reload.updated_at }
     end
   end
 

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe Collection do
   it { is_expected.to have_and_belong_to_many(:browse_entries) }
+  it { is_expected.to have_one(:page_landing).dependent(:destroy) }
   it { is_expected.to validate_presence_of(:key) }
   it { is_expected.to validate_uniqueness_of(:key) }
   it { is_expected.to validate_presence_of(:api_params) }
@@ -23,5 +24,35 @@ RSpec.describe Collection do
   describe '.settings_default_search_layout_enum' do
     subject { described_class.settings_default_search_layout_enum }
     it { is_expected.to eq(%w(list grid)) }
+  end
+
+  describe '#landing_page' do
+    context 'when it is the all collection' do
+      let(:collection) { collections(:all) }
+      it 'should return the corresponding page_landing' do
+        expect(collection.landing_page).to eq collection.page_landing
+      end
+    end
+
+    context 'when it is a thematic collection' do
+      let(:collection) { collections(:music) }
+      it 'should return the corresponding page_landing' do
+        expect(collection.landing_page).to eq collection.page_landing
+      end
+    end
+  end
+
+  describe '#has_landing_page?' do
+    context 'when there is NO landing page' do
+      let(:collection) { collections(:draft) }
+      subject { collection.has_landing_page? }
+      it { is_expected.to eq(false)}
+    end
+
+    context 'when there is a landing page' do
+      let(:collection) { collections(:music) }
+      subject { collection.has_landing_page? }
+      it { is_expected.to eq(true)}
+    end
   end
 end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Collection do
   it { is_expected.to have_and_belong_to_many(:browse_entries) }
-  it { is_expected.to have_one(:page_landing).dependent(:destroy) }
+  it { is_expected.to have_one(:landing_page).dependent(:destroy) }
   it { is_expected.to validate_presence_of(:key) }
   it { is_expected.to validate_uniqueness_of(:key) }
   it { is_expected.to validate_presence_of(:api_params) }
@@ -26,25 +26,9 @@ RSpec.describe Collection do
     it { is_expected.to eq(%w(list grid)) }
   end
 
-  describe '#landing_page' do
-    context 'when it is the all collection' do
-      let(:collection) { collections(:all) }
-      it 'should return the corresponding page_landing' do
-        expect(collection.landing_page).to eq collection.page_landing
-      end
-    end
-
-    context 'when it is a thematic collection' do
-      let(:collection) { collections(:music) }
-      it 'should return the corresponding page_landing' do
-        expect(collection.landing_page).to eq collection.page_landing
-      end
-    end
-  end
-
   describe '#has_landing_page?' do
     context 'when there is NO landing page' do
-      let(:collection) { collections(:draft) }
+      let(:collection) { collections(:internal) }
       subject { collection.has_landing_page? }
       it { is_expected.to eq(false) }
     end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -46,13 +46,13 @@ RSpec.describe Collection do
     context 'when there is NO landing page' do
       let(:collection) { collections(:draft) }
       subject { collection.has_landing_page? }
-      it { is_expected.to eq(false)}
+      it { is_expected.to eq(false) }
     end
 
     context 'when there is a landing page' do
       let(:collection) { collections(:music) }
       subject { collection.has_landing_page? }
-      it { is_expected.to eq(true)}
+      it { is_expected.to eq(true) }
     end
   end
 end

--- a/spec/models/page/landing_spec.rb
+++ b/spec/models/page/landing_spec.rb
@@ -25,8 +25,6 @@ RSpec.describe Page::Landing do
   end
 
   describe 'creation' do
-    subject { described_class.new }
-
     context 'when it is the all collection' do
       it 'should set the slug' do
         subject.collection = collections(:all)

--- a/spec/models/page/landing_spec.rb
+++ b/spec/models/page/landing_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Page::Landing do
   end
 
   describe '#set_slug' do
-    let(:page) { pages(:music_collection)}
+    let(:page) { pages(:music_collection) }
     context 'when the slug is empty' do
       before do
         page.slug = nil

--- a/spec/models/page/landing_spec.rb
+++ b/spec/models/page/landing_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe Page::Landing do
   it { is_expected.to belong_to(:hero_image) }
+  it { is_expected.to belong_to(:collection) }
   it { is_expected.to have_many(:credits) }
   it { is_expected.to have_many(:social_media) }
   it { is_expected.to have_many(:promotions) }
@@ -15,9 +16,44 @@ RSpec.describe Page::Landing do
   it { is_expected.to delegate_method(:file).to(:hero_image).with_prefix(true) }
 
   it { is_expected.to validate_inclusion_of(:settings_layout_type).in_array(%w(default browse)) }
+  it { is_expected.to validate_presence_of(:collection) }
+  it { is_expected.to validate_uniqueness_of(:collection) }
 
   describe 'modules' do
     subject { described_class }
     it { is_expected.to include(PaperTrail::Model::InstanceMethods) }
+  end
+
+  describe 'creation' do
+    subject { described_class.new }
+
+    context 'when it is the all collection' do
+      it 'should set the slug' do
+        subject.collection = collections(:all)
+        subject.run_callbacks :create
+        expect(subject.slug).to eq('')
+      end
+    end
+
+    context 'when it is a thematic collection' do
+      it 'should set the slug' do
+        subject.collection = collections(:music)
+        subject.run_callbacks :create
+        expect(subject.slug).to eq('collections/music')
+      end
+    end
+  end
+
+  describe '#set_slug' do
+    let(:page) { pages(:music_collection)}
+    context 'when the slug is empty' do
+      before do
+        page.slug = nil
+      end
+      it 'should set the slug' do
+        page.send(:set_slug)
+        expect(page.slug).to eq('collections/music')
+      end
+    end
   end
 end


### PR DESCRIPTION
These changes link collections and landing pages. This refactor is mainly in preparation for adding more authorization logic, so it also makes various adjustments to the CMS, most of which restrict the ability to change collection keys, or associations between collections and landing pages. This is in order to only allow these values to be set on creation of new collections/landingpages(which only administrators will be able to do)