### PR TITLE
cache hero_image_url for galleries head meta

### DIFF
--- a/app/controllers/galleries_controller.rb
+++ b/app/controllers/galleries_controller.rb
@@ -61,7 +61,7 @@ class GalleriesController < ApplicationController
   def set_gallery_hero_image_cache(image)
     image_document = @documents.detect { |document| document.fetch(:id, nil) == image.europeana_record_id }
     @hero_image_url = image_document['edmIsShownBy'].first
-    Rails.cache.write(cache_key(@body_cache_key) + '/hero_image_url', @hero_image_url, expires_in: 24.hours)
+    Rails.cache.write(cache_key(@body_cache_key) + '/hero_image_url', @hero_image_url, expires_in: 24.hours + 1.minute)
   end
 
   def blacklight_api_params_for_images(images)

--- a/app/views/galleries/show.html.mustache
+++ b/app/views/galleries/show.html.mustache
@@ -1,6 +1,5 @@
-
+{{>atoms/meta/_head}}
 {{#cached_body}}
-  {{>atoms/meta/_head}}
   {{>templates/Search/Gallery-page}}
 {{/cached_body}}
 {{>atoms/meta/_foot}}

--- a/app/views/galleries/show.rb
+++ b/app/views/galleries/show.rb
@@ -22,7 +22,7 @@ module Galleries
         head_meta = gallery_head_meta + [
           { meta_name: 'description', content: description },
           { meta_property: 'og:description', content: description },
-          { meta_property: 'og:image', content: gallery_items_content.first[:full_url] },
+          { meta_property: 'og:image', content: @hero_image_url },
           { meta_property: 'og:title', content: @gallery.title },
           { meta_property: 'og:sitename', content: @gallery.title }
         ]
@@ -49,7 +49,7 @@ module Galleries
 
     def gallery_hero_content
       {
-        url: gallery_items_content.first[:full_url],
+        url: @hero_image_url,
         title: @gallery.title,
         subtitle: @gallery.description
       }

--- a/spec/controllers/galleries_controller_spec.rb
+++ b/spec/controllers/galleries_controller_spec.rb
@@ -108,9 +108,15 @@ RSpec.describe GalleriesController do
         expect(assigns[:gallery]).to eq(gallery)
       end
 
-      it 'assigns gallery to @gallery' do
+      it 'assigns the edmIsShownBy of the first image to @hero_image_url' do
         get :show, locale: 'en', slug: gallery.slug
-        expect(assigns[:gallery]).to eq(gallery)
+        expect(assigns[:hero_image_url]).to eq('providerurl/sample/record1')
+      end
+
+      it 'caches the hero_image_url' do
+        expect(Rails.cache).to_not receive(:fetch)
+        expect(Rails.cache).to receive(:write).with(an_instance_of(String), an_instance_of(String), expires_in: 24.hours)
+        get :show, locale: 'en', slug: gallery.slug
       end
 
       it 'searches the API for the gallery image metadata' do
@@ -130,6 +136,13 @@ RSpec.describe GalleriesController do
         it 'does NOT searche the API for the gallery image metadata' do
           get :show, locale: 'en', slug: gallery.slug
           expect(an_api_search_request).to_not have_been_made
+        end
+
+        it 'assigns a url from the cache to @hero_image_url' do
+          expect(Rails.cache).to_not receive(:write)
+          expect(Rails.cache).to receive(:fetch) { 'something' }
+          get :show, locale: 'en', slug: gallery.slug
+          expect(assigns[:hero_image_url]).to eq('something')
         end
       end
     end

--- a/spec/controllers/galleries_controller_spec.rb
+++ b/spec/controllers/galleries_controller_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe GalleriesController do
 
       it 'caches the hero_image_url' do
         expect(Rails.cache).to_not receive(:fetch)
-        expect(Rails.cache).to receive(:write).with(an_instance_of(String), an_instance_of(String), expires_in: 24.hours)
+        expect(Rails.cache).to receive(:write).with(an_instance_of(String), an_instance_of(String), expires_in: 24.hours + 1.minute)
         get :show, locale: 'en', slug: gallery.slug
       end
 

--- a/spec/fixtures/api_response/search.json.erb
+++ b/spec/fixtures/api_response/search.json.erb
@@ -1,7 +1,7 @@
 <%
 items = (0..20).map do |index|
   id = '/sample/record' + index.to_s
-  '{"id":"' + id + '","title":["' + id + '"]}'
+  '{"id":"' + id + '","title":["' + id + '"],"edmIsShownBy":["providerurl' + id + '"]}'
 end
 %>
 {

--- a/spec/fixtures/gallery_images.yml
+++ b/spec/fixtures/gallery_images.yml
@@ -1,6 +1,6 @@
 fashion_dresses_image1:
   gallery: fashion_dresses
-  europeana_record_id: /dresses/1
+  europeana_record_id: /sample/record1
   position: 1
 
 fashion_dresses_image2:

--- a/spec/models/gallery_spec.rb
+++ b/spec/models/gallery_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe Gallery do
 
   describe '#image_portal_urls' do
     it 'should return a new line-separated list of gallery image record URLs' do
-      expect(galleries(:fashion_dresses).image_portal_urls).to eq("http://www.europeana.eu/portal/record/dresses/1.html\n\nhttp://www.europeana.eu/portal/record/dresses/2.html")
+      expect(galleries(:fashion_dresses).image_portal_urls).to eq("http://www.europeana.eu/portal/record/sample/record1.html\n\nhttp://www.europeana.eu/portal/record/dresses/2.html")
     end
   end
 


### PR DESCRIPTION
This adds the hero_image_url for gallery show pages to the cache so it's also available when we don't make an API request because we have cached the page body.

I guess there is a small chance that the image url which is written to the cache expires a few milliseconds before the page's cached body expires, in which case it potentially could lead to the og metadata being left blank for a request during that time. However the likelihood of this is very remote and the consequences not really significant.