### PR TITLE
Blog listing display

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,9 +59,10 @@
 ## HTTP_HOST, or left blank. No trailing slash.
 # EUROPEANA_OPENSEARCH_HOST=http://opensearch.example.com
 
-## Set the base URL for the Europeana Pro JSON-API, with trailing slash.
-# Defaults to <http://pro.europeana.eu/json/>.
-# EUROPEANA_PRO_JSON_API_URL=http://pro.example.com/json/
+## Set the base URL for the Europeana Pro site, without trailing slash. This
+## site is expected to respond to JSON-API requests at /json/.
+## Defaults to <http://pro.europeana.eu>.
+# EUROPEANA_PRO_URL=http://pro.example.com
 
 ## Set the URL of the styleguide to use for CSS, JS and image assets. Defaults
 ## to <http://styleguide.europeana.eu>. No trailing slash.

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'rails', '4.2.7.1'
 
 # NB: this *must* be by Git ref; else will break asset versioning in
 #     config/initializers/assets.rb, preventing app startup
-gem 'europeana-styleguide', github: 'europeana/europeana-styleguide-ruby', ref: 'd0c168b'
+gem 'europeana-styleguide', github: 'europeana/europeana-styleguide-ruby', ref: 'ec5ffab'
 
 # Use a forked version of stache with downstream changes, until merged upstream
 # @see https://github.com/agoragames/stache/pulls/rwd

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'rails', '4.2.7.1'
 
 # NB: this *must* be by Git ref; else will break asset versioning in
 #     config/initializers/assets.rb, preventing app startup
-gem 'europeana-styleguide', github: 'europeana/europeana-styleguide-ruby', ref: '3d08424'
+gem 'europeana-styleguide', github: 'europeana/europeana-styleguide-ruby', ref: '8f13391'
 
 # Use a forked version of stache with downstream changes, until merged upstream
 # @see https://github.com/agoragames/stache/pulls/rwd

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'rails', '4.2.7.1'
 
 # NB: this *must* be by Git ref; else will break asset versioning in
 #     config/initializers/assets.rb, preventing app startup
-gem 'europeana-styleguide', github: 'europeana/europeana-styleguide-ruby', ref: '8f13391'
+gem 'europeana-styleguide', github: 'europeana/europeana-styleguide-ruby', ref: 'd0c168b'
 
 # Use a forked version of stache with downstream changes, until merged upstream
 # @see https://github.com/agoragames/stache/pulls/rwd

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,8 +24,8 @@ GIT
 
 GIT
   remote: git://github.com/europeana/europeana-styleguide-ruby.git
-  revision: d0c168be1493343822cba2e9f98034c65001f5ac
-  ref: d0c168b
+  revision: ec5ffabc0e4b1a65212aa83d958436970db635fb
+  ref: ec5ffab
   specs:
     europeana-styleguide (0.2.0)
       activesupport (~> 4.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,8 +24,8 @@ GIT
 
 GIT
   remote: git://github.com/europeana/europeana-styleguide-ruby.git
-  revision: 8f133914720f895c08b68121ce156beaa3d0a8ac
-  ref: 8f13391
+  revision: d0c168be1493343822cba2e9f98034c65001f5ac
+  ref: d0c168b
   specs:
     europeana-styleguide (0.2.0)
       activesupport (~> 4.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,8 +24,8 @@ GIT
 
 GIT
   remote: git://github.com/europeana/europeana-styleguide-ruby.git
-  revision: 3d084242509a8ac674dae61a6888c8fc5fc6189e
-  ref: 3d08424
+  revision: 8f133914720f895c08b68121ce156beaa3d0a8ac
+  ref: 8f13391
   specs:
     europeana-styleguide (0.2.0)
       activesupport (~> 4.0)

--- a/app/controllers/blog_posts_controller.rb
+++ b/app/controllers/blog_posts_controller.rb
@@ -6,6 +6,8 @@
 # @todo Exception handling when `JsonApiClient` requests fail
 # @todo Extract pagination into a controller concern
 class BlogPostsController < ApplicationController
+  include HomepageHeroImage
+
   def index
     @blog_posts = Pro::BlogPost.includes(:network).page(blog_posts_page).per(6).all
     @hero_image = homepage_hero_image
@@ -15,10 +17,5 @@ class BlogPostsController < ApplicationController
 
   def blog_posts_page
     (params[:page] || 1).to_i
-  end
-
-  def homepage_hero_image
-    landing_page = Page::Landing.find_by_slug('')
-    landing_page.nil? ? nil : landing_page.hero_image
   end
 end

--- a/app/controllers/blog_posts_controller.rb
+++ b/app/controllers/blog_posts_controller.rb
@@ -9,7 +9,9 @@ class BlogPostsController < ApplicationController
   include HomepageHeroImage
 
   def index
-    @blog_posts = Pro::BlogPost.includes(:network).page(blog_posts_page).per(6).all
+    @pagination_page = blog_posts_page
+    @pagination_per = blog_posts_per
+    @blog_posts = Pro::BlogPost.includes(:network).page(@pagination_page).per(@pagination_per).all
     @hero_image = homepage_hero_image
   end
 
@@ -17,5 +19,9 @@ class BlogPostsController < ApplicationController
 
   def blog_posts_page
     (params[:page] || 1).to_i
+  end
+
+  def blog_posts_per
+    (params[:per_page] || 6).to_i
   end
 end

--- a/app/controllers/blog_posts_controller.rb
+++ b/app/controllers/blog_posts_controller.rb
@@ -8,11 +8,17 @@
 class BlogPostsController < ApplicationController
   def index
     @blog_posts = Pro::BlogPost.includes(:network).page(blog_posts_page).per(6).all
+    @hero_image = homepage_hero_image
   end
 
   protected
 
   def blog_posts_page
     (params[:page] || 1).to_i
+  end
+
+  def homepage_hero_image
+    landing_page = Page::Landing.find_by_slug('')
+    landing_page.nil? ? nil : landing_page.hero_image
   end
 end

--- a/app/controllers/concerns/homepage_hero_image.rb
+++ b/app/controllers/concerns/homepage_hero_image.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+module HomepageHeroImage
+  include ActiveSupport::Concern
+
+  def homepage_hero_image
+    homepage = Page::Landing.home
+    homepage.nil? ? nil : homepage.hero_image
+  end
+end

--- a/app/controllers/galleries_controller.rb
+++ b/app/controllers/galleries_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 class GalleriesController < ApplicationController
   include CacheHelper
+  include HomepageHeroImage
+
   attr_reader :body_cache_key
 
   def index
@@ -54,11 +56,6 @@ class GalleriesController < ApplicationController
 
   def search_api_query_for_images(images)
     'europeana_id:("' + images.map(&:europeana_record_id).join('" OR "') + '")'
-  end
-
-  def homepage_hero_image
-    landing_page = Page::Landing.find_by_slug('')
-    landing_page.nil? ? nil : landing_page.hero_image
   end
 
   def gallery_page

--- a/app/models/page/landing.rb
+++ b/app/models/page/landing.rb
@@ -24,6 +24,10 @@ class Page::Landing < Page
     def settings_layout_type_enum
       %w(default browse)
     end
+
+    def home
+      find_by_slug('')
+    end
   end
 
   def settings_layout_type

--- a/app/models/pro.rb
+++ b/app/models/pro.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+module Pro
+  class << self
+    attr_accessor :site
+  end
+  self.site = ENV['EUROPEANA_PRO_URL'] || 'http://pro.europeana.eu'
+end

--- a/app/models/pro.rb
+++ b/app/models/pro.rb
@@ -3,5 +3,5 @@ module Pro
   class << self
     attr_accessor :site
   end
-  self.site = ENV['EUROPEANA_PRO_URL'] || 'http://pro.europeana.eu'
+  self.site = Rails.application.config.x.europeana[:pro_url]
 end

--- a/app/models/pro/base.rb
+++ b/app/models/pro/base.rb
@@ -4,10 +4,10 @@ module Pro
   # Base class for JSON-API resources consumed from the Europeana Pro Bolt CMS
   # via its json-api extension.
   class Base < JsonApiClient::Resource
-    self.site = (ENV['EUROPEANA_PRO_URL'] || 'http://pro.europeana.eu') + '/json/'
+    self.site = Pro.site + '/json/'
 
-    def self.table_name
-      to_s.pluralize.demodulize.downcase
+    def url
+      [Pro.site, self.class.table_name, slug].join('/')
     end
   end
 end

--- a/app/models/pro/base.rb
+++ b/app/models/pro/base.rb
@@ -4,7 +4,7 @@ module Pro
   # Base class for JSON-API resources consumed from the Europeana Pro Bolt CMS
   # via its json-api extension.
   class Base < JsonApiClient::Resource
-    self.site = ENV['EUROPEANA_PRO_JSON_API_URL'] || 'http://pro.europeana.eu/json/'
+    self.site = (ENV['EUROPEANA_PRO_URL'] || 'http://pro.europeana.eu') + '/json/'
 
     def self.table_name
       to_s.pluralize.demodulize.downcase

--- a/app/models/pro/blog_post.rb
+++ b/app/models/pro/blog_post.rb
@@ -3,5 +3,8 @@ module Pro
   ##
   # Blog posts from Pro JSON-API.
   class BlogPost < Base
+    def self.table_name
+      'blogposts'
+    end
   end
 end

--- a/app/models/pro/network.rb
+++ b/app/models/pro/network.rb
@@ -3,5 +3,8 @@ module Pro
   ##
   # Networks, e.g. authors, from Pro JSON-API.
   class Network < Base
+    def self.table_name
+      'network'
+    end
   end
 end

--- a/app/views/blog_posts/index.html.mustache
+++ b/app/views/blog_posts/index.html.mustache
@@ -1,3 +1,3 @@
 {{>atoms/meta/_head}}
-  {{>templates/Search/Search-static-page}}
+  {{>templates/Search/Search-blog-list}}
 {{>atoms/meta/_foot}}

--- a/app/views/blog_posts/index.rb
+++ b/app/views/blog_posts/index.rb
@@ -6,7 +6,7 @@ module BlogPosts
 
     def page_title
       mustache[:page_title] ||= begin
-        ['Europeana Blog', site_title].join(' - ') # @todo Localeapp
+        [t('site.blogs.list.page-title'), site_title].join(' - ')
       end
     end
 

--- a/app/views/blog_posts/index.rb
+++ b/app/views/blog_posts/index.rb
@@ -30,8 +30,8 @@ module BlogPosts
 
     protected
 
-    def pagination_page_item_count
-      @blog_posts.count
+    def paginated_set
+      @blog_posts
     end
 
     def pagination_current_page

--- a/app/views/blog_posts/index.rb
+++ b/app/views/blog_posts/index.rb
@@ -1,27 +1,133 @@
 # frozen_string_literal: true
 module BlogPosts
+  # @todo move the blog_item_x methods into a presenter?
   class Index < ApplicationView
+    include PaginatedView
+
     def page_title
       mustache[:page_title] ||= begin
-        ['Blog posts', site_title].join(' - ') # @todo Localeapp
+        ['Europeana Blog', site_title].join(' - ') # @todo Localeapp
       end
     end
 
-    def content
-      mustache[:content] ||= begin
+    def navigation
+      mustache[:navigation] ||= begin
         {
-          title: 'Blog posts', # @todo Localeapp
-          text: '<ol>' + @blog_posts.map { |bp| "<li>#{bp.title}#{blog_post_authors(bp)}</li>" }.join + '</ol>',
+          pagination: pagination_navigation
         }.reverse_merge(super)
       end
     end
 
+    def blog_items
+      @blog_posts.map { |post| blog_item(post) }
+    end
+
     protected
 
-    def blog_post_authors(blog_post)
-      return nil unless blog_post.respond_to?(:network) && blog_post.network.present?
+    def pagination_page_item_count
+      @blog_posts.count
+    end
 
-      author_names = blog_post.network.compact.map do |network|
+    def pagination_current_page
+      mustache[:pagination_current_page] ||= begin
+        # JsonApiClient::ResultSet#current_page always returns 1 here for some reason
+        # @blog_posts.current_page
+
+        # Get it out of the JSON API self link instead
+        current_page_api_query = URI.parse(@blog_posts.links.links['self']).query
+        Rack::Utils.parse_nested_query(current_page_api_query)['page']['number'].to_i
+      end
+    end
+
+    def pagination_per_page
+      mustache[:pagination_per_page] ||= begin
+        # JsonApiClient::ResultSet#per_page always returns number in this page
+        # here for some reason
+        # @blog_posts.per_page
+
+        # Get it out of the JSON API self link instead
+        current_page_api_query = URI.parse(@blog_posts.links.links['self']).query
+        Rack::Utils.parse_nested_query(current_page_api_query)['page']['size'].to_i
+      end
+    end
+
+    def pagination_total
+      # JsonApiClient::ResultSet#total_count always returns number in this page
+      # here for some reason
+      # @blog_posts.total_pages
+      @blog_posts.meta.total
+    end
+
+    def pagination_total_pages
+      mustache[:pagination_total_pages] ||= begin
+        # JsonApiClient::ResultSet#total_pages always returns 1 here for some reason
+        # @blog_posts.total_pages
+        (pagination_total / pagination_per_page) +
+          ((pagination_total / pagination_per_page).zero? ? 0 : 1)
+      end
+    end
+
+    def pro_blog_url(path)
+      ENV['EUROPEANA_PRO_URL'] + path
+    end
+
+    def blog_item(post)
+      {
+        author: blog_item_author(post),
+        title: post.title,
+        description: blog_item_description(post),
+        read_time: 'HOW IS READ TIME CALCULATED?',
+        date: blog_item_date(post),
+        img: blog_item_image(post),
+        tags: blog_item_tags(post),
+        label: blog_item_label(post)
+      }
+    end
+
+    def blog_item_tags(post)
+      return nil unless post.respond_to?(:taxonomy)
+      return nil unless post.taxonomy.key?(:tags) && post.taxonomy[:tags].present?
+      { items: blog_item_tags_items(post) }
+    end
+
+    def blog_item_tags_items(post)
+      post.taxonomy[:tags].map do |k, v|
+        {
+          url: pro_blog_url(k),
+          text: v
+        }
+      end
+    end
+
+    def blog_item_image(post)
+      return nil unless post.respond_to?(:image) && post.image.is_a?(Hash)
+      return nil unless post.image.key?(:thumbnail) && post.image[:thumbnail].present?
+      {
+        src: post.image[:thumbnail],
+        alt: post.image[:title]
+      }
+    end
+
+    def blog_item_date(post)
+      DateTime.strptime(post.datepublish).strftime('%-d %B, %Y') # @todo Localeapp the date format
+    end
+
+    def blog_item_description(post)
+      truncate(strip_tags(post.body), length: 350, separator: ' ')
+    end
+
+    def blog_item_label(post)
+      return nil unless post.respond_to?(:taxonomy)
+      return nil unless post.taxonomy.key?(:blogs) && post.taxonomy[:blogs].present?
+      post.taxonomy[:blogs].values.first
+    end
+
+    # @todo return actual content when template can support multiple authors
+    def blog_item_author(post)
+      return { name: 'TODO PENDING MULTI-AUTHOR SUPPORT IN TEMPLATE' }
+      return nil unless post.respond_to?(:network) && post.network.present?
+
+      author_names = post.network.compact.map do |network|
         "#{network.first_name} #{network.last_name}"
       end.join(', ')
       " (#{author_names})"

--- a/app/views/blog_posts/index.rb
+++ b/app/views/blog_posts/index.rb
@@ -68,15 +68,15 @@ module BlogPosts
     end
 
     def pro_blog_url(path)
-      ENV['EUROPEANA_PRO_URL'] + path
+      Pro.site + path
     end
 
     def blog_item(post)
       {
-        author: blog_item_author(post),
+        authors: blog_item_authors(post),
         title: post.title,
         description: blog_item_description(post),
-        read_time: 'HOW IS READ TIME CALCULATED?',
+        read_time: '??',
         date: blog_item_date(post),
         img: blog_item_image(post),
         tags: blog_item_tags(post),
@@ -122,15 +122,15 @@ module BlogPosts
       post.taxonomy[:blogs].values.first
     end
 
-    # @todo return actual content when template can support multiple authors
-    def blog_item_author(post)
-      return { name: 'TODO PENDING MULTI-AUTHOR SUPPORT IN TEMPLATE' }
+    def blog_item_authors(post)
       return nil unless post.respond_to?(:network) && post.network.present?
 
-      author_names = post.network.compact.map do |network|
-        "#{network.first_name} #{network.last_name}"
-      end.join(', ')
-      " (#{author_names})"
+      post.network.compact.map do |network|
+        {
+          name: "#{network.first_name} #{network.last_name}",
+          url: network.url
+        }
+      end
     end
   end
 end

--- a/app/views/blog_posts/index.rb
+++ b/app/views/blog_posts/index.rb
@@ -98,10 +98,10 @@ module BlogPosts
     def blog_item_tags_items(post)
       return nil unless post.respond_to?(:taxonomy)
       return nil unless post.taxonomy.key?(:tags) && post.taxonomy[:tags].present?
-      post.taxonomy[:tags].map do |k, v|
+      post.taxonomy[:tags].map do |pro_path, tag|
         {
-          url: pro_blog_url(k),
-          text: v
+          url: pro_blog_url(pro_path),
+          text: tag
         }
       end
     end

--- a/app/views/blog_posts/index.rb
+++ b/app/views/blog_posts/index.rb
@@ -76,7 +76,7 @@ module BlogPosts
         authors: blog_item_authors(post),
         title: post.title,
         description: blog_item_description(post),
-        read_time: '??',
+        read_time: nil,
         date: blog_item_date(post),
         img: blog_item_image(post),
         tags: blog_item_tags(post),

--- a/app/views/blog_posts/index.rb
+++ b/app/views/blog_posts/index.rb
@@ -91,12 +91,13 @@ module BlogPosts
     end
 
     def blog_item_tags(post)
-      return nil unless post.respond_to?(:taxonomy)
-      return nil unless post.taxonomy.key?(:tags) && post.taxonomy[:tags].present?
-      { items: blog_item_tags_items(post) }
+      items = blog_item_tags_items(post)
+      items.nil? ? nil : { items: items }
     end
 
     def blog_item_tags_items(post)
+      return nil unless post.respond_to?(:taxonomy)
+      return nil unless post.taxonomy.key?(:tags) && post.taxonomy[:tags].present?
       post.taxonomy[:tags].map do |k, v|
         {
           url: pro_blog_url(k),

--- a/app/views/blog_posts/index.rb
+++ b/app/views/blog_posts/index.rb
@@ -10,6 +10,12 @@ module BlogPosts
       end
     end
 
+    def hero
+      {
+        hero_image: @hero_image.file.present? ? @hero_image.file.url : nil
+      }
+    end
+
     def navigation
       mustache[:navigation] ||= begin
         {

--- a/app/views/blog_posts/index.rb
+++ b/app/views/blog_posts/index.rb
@@ -12,7 +12,7 @@ module BlogPosts
 
     def hero
       {
-        hero_image: (@hero_image.present? && @hero_image.file.present?) ? @hero_image.file.url : nil
+        hero_image: @hero_image.present? && @hero_image.file.present? ? @hero_image.file.url : nil
       }
     end
 

--- a/app/views/blog_posts/index.rb
+++ b/app/views/blog_posts/index.rb
@@ -12,7 +12,7 @@ module BlogPosts
 
     def hero
       {
-        hero_image: @hero_image.file.present? ? @hero_image.file.url : nil
+        hero_image: (@hero_image.present? && @hero_image.file.present?) ? @hero_image.file.url : nil
       }
     end
 

--- a/app/views/blog_posts/index.rb
+++ b/app/views/blog_posts/index.rb
@@ -39,9 +39,8 @@ module BlogPosts
         # JsonApiClient::ResultSet#current_page always returns 1 here for some reason
         # @blog_posts.current_page
 
-        # Get it out of the JSON API self link instead
-        current_page_api_query = URI.parse(@blog_posts.links.links['self']).query
-        Rack::Utils.parse_nested_query(current_page_api_query)['page']['number'].to_i
+        # Get it out of the controller-assigned var instead
+        @pagination_page
       end
     end
 
@@ -51,9 +50,8 @@ module BlogPosts
         # here for some reason
         # @blog_posts.per_page
 
-        # Get it out of the JSON API self link instead
-        current_page_api_query = URI.parse(@blog_posts.links.links['self']).query
-        Rack::Utils.parse_nested_query(current_page_api_query)['page']['size'].to_i
+        # Get it out of the controller-assigned var instead
+        @pagination_per
       end
     end
 
@@ -61,7 +59,11 @@ module BlogPosts
       # JsonApiClient::ResultSet#total_count always returns number in this page
       # here for some reason
       # @blog_posts.total_pages
-      @blog_posts.meta.total
+      if @blog_posts.respond_to?(:meta) && @blog_posts.meta.respond_to?(:total)
+        @blog_posts.meta.total
+      else
+        0
+      end
     end
 
     def pagination_total_pages

--- a/app/views/concerns/paginated_view.rb
+++ b/app/views/concerns/paginated_view.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+module PaginatedView
+  extend ActiveSupport::Concern
+
+  protected
+
+  def paginated_set_range(current_page, per_page, total)
+    result_number_from = ((current_page - 1) * per_page) + 1
+    result_number_to   = [result_number_from + per_page - 1, total].min
+    result_number_from.to_s + ' - ' + result_number_to.to_s
+  end
+end

--- a/app/views/concerns/paginated_view.rb
+++ b/app/views/concerns/paginated_view.rb
@@ -110,12 +110,10 @@ module PaginatedView
   end
 
   def pagination_previous_page_url
-    prev_page = Kaminari::Helpers::PrevPage.new(self, current_page: pagination_current_page)
-    prev_page.url
+    Kaminari::Helpers::PrevPage.new(self, current_page: pagination_current_page).url
   end
 
   def pagination_next_page_url
-    next_page = Kaminari::Helpers::NextPage.new(self, current_page: pagination_current_page)
-    next_page.url
+    Kaminari::Helpers::NextPage.new(self, current_page: pagination_current_page).url
   end
 end

--- a/app/views/concerns/paginated_view.rb
+++ b/app/views/concerns/paginated_view.rb
@@ -19,23 +19,26 @@ module PaginatedView
     number_with_delimiter(pagination_total)
   end
 
-  def has_results
+  def has_results?
     mustache[:has_results] ||= begin
-      pagination_page_item_count > 0
+      pagination_page_item_count.positive?
     end
   end
+  alias_method :has_results, :has_results?
 
-  def has_single_result
+  def has_single_result?
     mustache[:has_single_result] ||= begin
       pagination_page_item_count == 1
     end
   end
+  alias_method :has_single_result, :has_single_result?
 
-  def has_multiple_results
+  def has_multiple_results?
     mustache[:has_multiple_results] ||= begin
       pagination_page_item_count > 1
     end
   end
+  alias_method :has_multiple_results, :has_multiple_results?
 
   protected
 

--- a/app/views/concerns/paginated_view.rb
+++ b/app/views/concerns/paginated_view.rb
@@ -1,11 +1,7 @@
 # frozen_string_literal: true
 ##
-# Including view are expected to implement:
-# * `pagination_current_page`
-# * `pagination_page_item_count`
-# * `pagination_per_page`
-# * `pagination_total`
-# * `pagination_total_pages`
+# Including view are expected to implement `pagination_set`, returning the set
+# of paginated objects to render links for.
 module PaginatedView
   extend ActiveSupport::Concern
 
@@ -41,6 +37,30 @@ module PaginatedView
   alias_method :has_multiple_results, :has_multiple_results?
 
   protected
+
+  def paginated_set
+    fail NotImplementedError, 'Including view class must implement #paginated_set'
+  end
+
+  def pagination_current_page
+    paginated_set.current_page
+  end
+
+  def pagination_per_page
+    paginated_set.limit_value
+  end
+
+  def pagination_total
+    paginated_set.total
+  end
+
+  def pagination_total_pages
+    paginated_set.total_pages
+  end
+
+  def pagination_page_item_count
+    paginated_set.count
+  end
 
   def pagination_first_page?
     pagination_current_page == 1

--- a/app/views/concerns/paginated_view.rb
+++ b/app/views/concerns/paginated_view.rb
@@ -1,12 +1,98 @@
 # frozen_string_literal: true
+##
+# Including view are expected to implement:
+# * `pagination_current_page`
+# * `pagination_page_item_count`
+# * `pagination_per_page`
+# * `pagination_total`
+# * `pagination_total_pages`
 module PaginatedView
   extend ActiveSupport::Concern
 
+  def results_range
+    result_number_from = ((pagination_current_page - 1) * pagination_per_page) + 1
+    result_number_to   = [result_number_from + pagination_per_page - 1, pagination_total].min
+    result_number_from.to_s + ' - ' + result_number_to.to_s
+  end
+
+  def results_count
+    number_with_delimiter(pagination_total)
+  end
+
+  def has_results
+    mustache[:has_results] ||= begin
+      pagination_page_item_count > 0
+    end
+  end
+
+  def has_single_result
+    mustache[:has_single_result] ||= begin
+      pagination_page_item_count == 1
+    end
+  end
+
+  def has_multiple_results
+    mustache[:has_multiple_results] ||= begin
+      pagination_page_item_count > 1
+    end
+  end
+
   protected
 
-  def paginated_set_range(current_page, per_page, total)
-    result_number_from = ((current_page - 1) * per_page) + 1
-    result_number_to   = [result_number_from + per_page - 1, total].min
-    result_number_from.to_s + ' - ' + result_number_to.to_s
+  def pagination_first_page?
+    pagination_current_page == 1
+  end
+
+  def pagination_last_page?
+    pagination_current_page == pagination_total_pages
+  end
+
+  def pagination_navigation
+    {
+      prev_url: pagination_previous_page_url,
+      next_url: pagination_next_page_url,
+      is_first_page: pagination_first_page?,
+      is_last_page: pagination_last_page?,
+      pages: pagination_pages.collect.each_with_index do |page, i|
+        {
+          url: Kaminari::Helpers::Page.new(self, page: page.number).url,
+          index: number_with_delimiter(page.number),
+          is_current: (pagination_current_page == page.number),
+          separator: show_pagination_separator?(i, page.number, pagination_pages.size)
+        }
+      end
+    }
+  end
+
+  def pagination_pages
+    mustache[:pagination_pages] ||= begin
+      opts = {
+        total_pages: pagination_total_pages,
+        current_page: pagination_current_page,
+        per_page: pagination_per_page,
+        remote: false,
+        window: 3
+      }
+      [].tap do |pages|
+        Kaminari::Helpers::Paginator.new(self, opts).each_relevant_page do |p|
+          pages << p
+        end
+      end
+    end
+  end
+
+  def show_pagination_separator?(page_index, page_number, pages_shown)
+    (page_index == 1 && pagination_current_page > 2) ||
+      (page_index == (pages_shown - 2) && (page_number + 1) < pagination_total_pages)
+  end
+
+  def pagination_previous_page_url
+    prev_page = Kaminari::Helpers::PrevPage.new(self, current_page: pagination_current_page)
+    prev_page.url
+  end
+
+  def pagination_next_page_url
+    next_page = Kaminari::Helpers::NextPage.new(self, current_page: pagination_current_page)
+    next_page.url
   end
 end

--- a/app/views/galleries/index.rb
+++ b/app/views/galleries/index.rb
@@ -2,6 +2,7 @@
 module Galleries
   class Index < ApplicationView
     include GalleryDisplayingView
+    include PaginatedView
 
     def bodyclass
       'channel_landing'
@@ -43,36 +44,17 @@ module Galleries
     end
 
     def navigation
-      {
-        pagination: {
-          prev_url: prev_page.url,
-          next_url: next_page.url,
-          is_first_page: @galleries.first_page?,
-          is_last_page: @galleries.last_page?,
-          pages: navigation_pagination_pages
-        }
-      }.reverse_merge(super)
-    end
-
-    private
-
-    def navigation_pagination_pages
-      (1..@galleries.total_pages).map do |number|
-        page = Kaminari::Helpers::Page.new(self, page: number)
+      mustache[:navigation] ||= begin
         {
-          url: page.url,
-          index: number,
-          is_current: number == @galleries.current_page
-        }
+          pagination: pagination_navigation
+        }.reverse_merge(super)
       end
     end
 
-    def prev_page
-      @prev_page ||= Kaminari::Helpers::PrevPage.new(self, current_page: @galleries.current_page)
-    end
+    protected
 
-    def next_page
-      @next_page ||= Kaminari::Helpers::NextPage.new(self, current_page: @galleries.current_page)
+    def paginated_set
+      @galleries
     end
 
     def hero_content

--- a/app/views/portal/index.rb
+++ b/app/views/portal/index.rb
@@ -4,6 +4,7 @@ module Portal
   class Index < ApplicationView
     include SearchableView
     include HeroImageDisplayingView
+    include PaginatedView
 
     def js_vars
       [{ name: 'pageName', value: 'portal/index' }]
@@ -99,9 +100,7 @@ module Portal
     end
 
     def results_range
-      result_number_from = ((@response.current_page - 1) * @response.limit_value) + 1
-      result_number_to   = [result_number_from + @response.limit_value - 1, response.total].min
-      result_number_from.to_s + ' - ' + result_number_to.to_s
+      paginated_set_range(@response.current_page, @response.limit_value, response.total)
     end
 
     def has_results

--- a/app/views/portal/index.rb
+++ b/app/views/portal/index.rb
@@ -210,24 +210,8 @@ module Portal
 
     private
 
-    def pagination_current_page
-      @response.current_page
-    end
-
-    def pagination_per_page
-      @response.limit_value
-    end
-
-    def pagination_total
-      @response.total
-    end
-
-    def pagination_total_pages
-      @response.total_pages
-    end
-
-    def pagination_page_item_count
-      @response.total
+    def paginated_set
+      @response
     end
 
     def facets_selected_items

--- a/config/initializers/env.rb
+++ b/config/initializers/env.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+# @todo Move all uses of env vars out of app/ logic and into this initializer,
+#   with app logic instead inspecting `Rails.application.config.x`
+Rails.application.config.x.europeana ||= {}
+Rails.application.config.x.europeana[:pro_url] = ENV['EUROPEANA_PRO_URL'] || 'http://pro.europeana.eu'

--- a/spec/controllers/blog_posts_controller_spec.rb
+++ b/spec/controllers/blog_posts_controller_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 RSpec.describe BlogPostsController do
-  JSON_API_URL = %r{\Ahttp://pro\.europeana\.eu/json/blogposts(\?|\z)}
+  JSON_API_URL = %r{\A#{Rails.application.config.x.europeana[:pro_url]}/json/blogposts(\?|\z)}
   JSON_API_CONTENT_TYPE = 'application/vnd.api+json'
 
   before do
@@ -30,6 +30,8 @@ RSpec.describe BlogPostsController do
         a_request(:get, JSON_API_URL).
         with(query: hash_including(page: { number: '1', size: '6' }))
       ).to have_been_made.once
+      expect(assigns(:pagination_per)).to eq(6)
+      expect(assigns(:pagination_page)).to eq(1)
     end
 
     it 'requests the page in `page` param' do
@@ -38,6 +40,8 @@ RSpec.describe BlogPostsController do
         a_request(:get, JSON_API_URL).
         with(query: hash_including(page: { number: '3', size: '6' }))
       ).to have_been_made.once
+      expect(assigns(:pagination_per)).to eq(6)
+      expect(assigns(:pagination_page)).to eq(3)
     end
 
     it 'includes related resources' do

--- a/spec/fixtures/api_response/pro_blog_posts.json.erb
+++ b/spec/fixtures/api_response/pro_blog_posts.json.erb
@@ -1,0 +1,102 @@
+{
+    "links": {
+        "self": "http:\/\/pro.example.com\/json\/blogposts?page[number]=1&page[size]=6&include=network"
+    },
+    "meta": {
+        "count": 1,
+        "total": 1
+    },
+    "data": [
+        {
+            "id": "1",
+            "type": "blogposts",
+            "attributes": {
+                "title": "Testpost for json-api",
+                "datepublish": "2017-02-15T14:12:00+00:00",
+                "body": "<p>This testpost also has a body.<\/p>",
+                "image": {
+                    "title": "Some image",
+                    "thumbnail": "http:\/\/pro.example.com\/thumbs\/test-post.jpg"
+                },
+                "taxonomy": {
+                    "tags": {
+                        "\/tags\/first": "first",
+                        "\/tags\/second": "second"
+                    },
+                    "blogs": {
+                        "\/blogs\/europeana-blog": "Europeana Blog"
+                    }
+                }
+            },
+            "relationships": {
+                "network": {
+                    "links": {
+                        "related": "http:\/\/pro.example.com\/json\/blogposts\/1\/network"
+                    },
+                    "data": [
+                        {
+                            "type": "network",
+                            "id": "2"
+                        },
+                        {
+                            "type": "network",
+                            "id": "3"
+                        }
+                    ]
+                }
+            }
+        }
+    ],
+    "included": [
+        {
+            "id": "2",
+            "type": "network",
+            "attributes": {
+                "first_name": "Joe",
+                "last_name": "Bloggs",
+                "slug": "joe-bloggs"
+            },
+            "links": {
+                "self": "http:\/\/pro.example.com\/json\/network\/2"
+            },
+            "relationships": {
+                "blogposts": {
+                    "links": {
+                        "related": "http:\/\/pro.example.com\/json\/network\/2\/blogposts"
+                    },
+                    "data": [
+                        {
+                            "type": "blogposts",
+                            "id": "1"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "id": "3",
+            "type": "network",
+            "attributes": {
+                "first_name": "Jane",
+                "last_name": "Bloggs",
+                "slug": "jane-bloggs"
+            },
+            "links": {
+                "self": "http:\/\/pro.example.com\/json\/network\/3"
+            },
+            "relationships": {
+                "blogposts": {
+                    "links": {
+                        "related": "http:\/\/pro.example.com\/json\/network\/3\/blogposts"
+                    },
+                    "data": [
+                        {
+                            "type": "blogposts",
+                            "id": "1"
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+}

--- a/spec/models/page/landing_spec.rb
+++ b/spec/models/page/landing_spec.rb
@@ -20,4 +20,10 @@ RSpec.describe Page::Landing do
     subject { described_class }
     it { is_expected.to include(PaperTrail::Model::InstanceMethods) }
   end
+
+  describe '.home' do
+    it 'should return the homepage' do
+      expect(described_class.home).to eq(pages(:home))
+    end
+  end
 end

--- a/spec/models/pro/base_spec.rb
+++ b/spec/models/pro/base_spec.rb
@@ -3,8 +3,8 @@ RSpec.describe Pro::Base do
   it { is_expected.to be_a(JsonApiClient::Resource) }
 
   describe '.site' do
-    it 'defaults to "http://pro.europeana.eu/json/"' do
-      expect(described_class.site).to eq('http://pro.europeana.eu/json/')
+    it 'appends /json/ to Pro.site' do
+      expect(described_class.site).to eq(%(#{Pro.site}/json/))
     end
   end
 end

--- a/spec/models/pro/network_spec.rb
+++ b/spec/models/pro/network_spec.rb
@@ -3,8 +3,8 @@ RSpec.describe Pro::Network do
   it { is_expected.to be_a(Pro::Base) }
 
   describe '.table_name' do
-    it 'should be "networks"' do
-      expect(described_class.table_name).to eq('networks')
+    it 'should be "network"' do
+      expect(described_class.table_name).to eq('network')
     end
   end
 end

--- a/spec/models/pro_spec.rb
+++ b/spec/models/pro_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 RSpec.describe Pro do
   describe '.site' do
-    it 'should default to "http://pro.europeana.eu"' do
-      expect(described_class.site).to eq('http://pro.europeana.eu')
+    it %(should be "#{Rails.application.config.x.europeana[:pro_url]}") do
+      expect(described_class.site).to eq(Rails.application.config.x.europeana[:pro_url])
     end
   end
 end

--- a/spec/models/pro_spec.rb
+++ b/spec/models/pro_spec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+RSpec.describe Pro do
+  describe '.site' do
+    it 'should default to "http://pro.europeana.eu"' do
+      expect(described_class.site).to eq('http://pro.europeana.eu')
+    end
+  end
+end

--- a/spec/views/blog_posts/index_spec.rb
+++ b/spec/views/blog_posts/index_spec.rb
@@ -3,6 +3,35 @@ require 'views/concerns/paginated_view_examples'
 
 RSpec.describe 'blog_posts/index.html.mustache' do
   let(:view_class) { BlogPosts::Index }
+  let(:pagination_per) { 6 }
+  let(:pagination_page) { 1 }
+  let(:blog_posts) do
+    api_response = double
+    allow(api_response).to receive(:body) { JSON.parse(api_responses(:pro_blog_posts)) }
+    allow(api_response).to receive(:env) { {} }
+    JsonApiClient::Parsers::Parser.parse(Pro::BlogPost, api_response)
+  end
+
+  before do
+    assign(:pagination_page, pagination_page)
+    assign(:pagination_per, pagination_per)
+    assign(:blog_posts, blog_posts)
+  end
 
   it_behaves_like 'paginated_view'
+
+  it 'has page title "Europeana Blog"' do
+    render
+    expect(rendered).to have_selector('title', text: /Europeana Blog/, visible: false)
+  end
+
+  it 'has h2 with post title' do
+    render
+    expect(rendered).to have_selector('h2 a', text: blog_posts.first.title)
+  end
+
+  it 'uses blogs taxonomy for category flag' do
+    render
+    expect(rendered).to have_selector('.item-preview .category-flag', text: blog_posts.first.taxonomy[:blogs].values.first)
+  end
 end

--- a/spec/views/blog_posts/index_spec.rb
+++ b/spec/views/blog_posts/index_spec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+require 'views/concerns/paginated_view_examples'
+
+RSpec.describe 'blog_posts/index.html.mustache' do
+  let(:view_class) { BlogPosts::Index }
+
+  it_behaves_like 'paginated_view'
+end

--- a/spec/views/concerns/paginated_view_examples.rb
+++ b/spec/views/concerns/paginated_view_examples.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+shared_examples_for 'paginated_view' do
+  describe 'view class' do
+    subject { view_class }
+    it { is_expected.to include(PaginatedView) }
+
+    it 'implements #paginated_set' do
+      expect { view_class.new.send(:paginated_set) }.not_to raise_exception
+    end
+  end
+end

--- a/spec/views/concerns/paginated_view_spec.rb
+++ b/spec/views/concerns/paginated_view_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+RSpec.describe PaginatedView do
+  let(:view_class) do
+    Class.new do
+      include PaginatedView
+    end
+  end
+
+  subject { view_class.new }
+
+  before do
+    allow(subject).to receive(:mustache) { {} }
+    allow(subject).to receive(:paginated_set) { paginated_set }
+  end
+
+  context 'when paginated set is empty' do
+    before do
+      allow(subject).to receive(:paginated_set) { [] }
+    end
+
+    it { is_expected.not_to have_results }
+    it { is_expected.not_to have_single_result }
+    it { is_expected.not_to have_multiple_results }
+  end
+
+  context 'when paginated set has one member' do
+    let(:paginated_set) { [4] }
+
+    it { is_expected.to have_results }
+    it { is_expected.to have_single_result }
+    it { is_expected.not_to have_multiple_results }
+  end
+
+  context 'when paginated set has multiple members' do
+    let(:paginated_set) { [1, 2] }
+
+    it { is_expected.to have_results }
+    it { is_expected.not_to have_single_result }
+    it { is_expected.to have_multiple_results }
+  end
+end

--- a/spec/views/galleries/index_spec.rb
+++ b/spec/views/galleries/index_spec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+require 'views/concerns/paginated_view_examples'
+
+RSpec.describe 'galleries/index.html.mustache' do
+  let(:view_class) { Galleries::Index }
+
+  it_behaves_like 'paginated_view'
+end

--- a/spec/views/portal/index_spec.rb
+++ b/spec/views/portal/index_spec.rb
@@ -1,3 +1,5 @@
+require 'views/concerns/paginated_view_examples'
+
 RSpec.describe 'portal/index.html.mustache', :common_view_components, :blacklight_config, :stable_version_view do
   before do
     assign(:response, response)
@@ -6,6 +8,8 @@ RSpec.describe 'portal/index.html.mustache', :common_view_components, :blackligh
     allow(view).to receive(:search_state).and_return(search_state)
     allow(controller).to receive(:params).and_return(blacklight_params)
   end
+
+  let(:view_class) { Portal::Index }
 
   let(:api_response) do
     {
@@ -25,6 +29,8 @@ RSpec.describe 'portal/index.html.mustache', :common_view_components, :blackligh
   let(:request_params) { { query: 'paris', rows: 12, start: 1 } }
   let(:response) { Europeana::Blacklight::Response.new(api_response, request_params) }
   let(:search_state) { Blacklight::SearchState.new(blacklight_params, blacklight_config) }
+
+  it_behaves_like 'paginated_view'
 
   it 'includes the search terms in the title' do
     render


### PR DESCRIPTION
* Extracts view logic for pagination into a PaginatedView concern, also used by main item search results and galleries listing
* Changes the Pro URL env var to be the base URL for the entire site, not that for the JSON API
* Implements most display elements for blog listing page, only missing read time (to come later)