### PR TITLE
Bug/1977 1986 https rights statements

### DIFF
--- a/app/controllers/concerns/blacklight_config.rb
+++ b/app/controllers/concerns/blacklight_config.rb
@@ -84,7 +84,7 @@ module BlacklightConfig
                              hierarchical: true,
                              parent: 'REUSABILITY',
                              splice: lambda { |parent, child|
-                               rights = EDM::Rights.for_api_query(child.value)
+                               rights = EDM::Rights.from_api_query(child.value)
                                rights.present? ? (parent.value == rights.reusability.to_s) : nil
                              },
                              group: lambda { |item|

--- a/app/models/edm/rights.rb
+++ b/app/models/edm/rights.rb
@@ -17,7 +17,7 @@ module EDM
       end
 
       def for_api_query(value)
-        registry.detect { |rights| value.match(rights.pattern)}
+        registry.detect { |rights| value.match(rights.pattern) }
       end
 
       def from_api_query(value)

--- a/app/models/edm/rights.rb
+++ b/app/models/edm/rights.rb
@@ -16,10 +16,6 @@ module EDM
         registry.detect { |rights| string.match(rights.pattern) }
       end
 
-      def for_api_query(value)
-        registry.detect { |rights| value.match(rights.pattern) }
-      end
-
       def from_api_query(value)
         simple_value = value.to_s.tr('?*', '')
         registry.detect { |rights| simple_value.match(rights.pattern) }
@@ -27,7 +23,7 @@ module EDM
     end
 
     def api_query
-      super || pattern.gsub(/\(.*\)\?|.\?/, '*') + '*'
+      pattern.gsub(/\(.*\)\?|.\?/, '*') + '*'
     end
 
     def i18n_key

--- a/app/models/edm/rights.rb
+++ b/app/models/edm/rights.rb
@@ -17,17 +17,17 @@ module EDM
       end
 
       def for_api_query(value)
-        registry.detect { |rights| Regexp.new(rights.pattern) =~ value }
+        registry.detect { |rights| value.match(rights.pattern)}
       end
 
       def from_api_query(value)
-        unescaped_value = value.to_s.tr('?*', '')
-        registry.detect { |rights| Regexp.new(rights.pattern) =~ unescaped_value }
+        simple_value = value.to_s.tr('?*', '')
+        registry.detect { |rights| simple_value.match(rights.pattern) }
       end
     end
 
     def api_query
-      super || pattern.sub(/\(.*\)\?|.\?/, '*') + '*'
+      super || pattern.gsub(/\(.*\)\?|.\?/, '*') + '*'
     end
 
     def i18n_key

--- a/app/models/edm/rights.rb
+++ b/app/models/edm/rights.rb
@@ -17,12 +17,17 @@ module EDM
       end
 
       def for_api_query(value)
-        registry.detect { |rights| rights.api_query == value }
+        registry.detect { |rights| Regexp.new(rights.pattern) =~ value }
+      end
+
+      def from_api_query(value)
+        unescaped_value = value.to_s.gsub('?', '').gsub('*', '')
+        registry.detect { |rights| Regexp.new(rights.pattern) =~ unescaped_value }
       end
     end
 
     def api_query
-      super || pattern + '*'
+      super || pattern.sub(/\(.*\)\?|.\?/, '*') + '*'
     end
 
     def i18n_key

--- a/app/models/edm/rights.rb
+++ b/app/models/edm/rights.rb
@@ -21,7 +21,7 @@ module EDM
       end
 
       def from_api_query(value)
-        unescaped_value = value.to_s.gsub('?', '').gsub('*', '')
+        unescaped_value = value.to_s.tr('?*', '')
         registry.detect { |rights| Regexp.new(rights.pattern) =~ unescaped_value }
       end
     end

--- a/app/presenters/concerns/facet/labelling.rb
+++ b/app/presenters/concerns/facet/labelling.rb
@@ -83,7 +83,7 @@ module Facet
       label_facet 'RIGHTS',
                   title: nil,
                   items: {
-                    with: ->(item) { EDM::Rights.for_api_query(item).label }
+                    with: ->(item) { EDM::Rights.from_api_query(item).label }
                   }
       label_facet 'COUNTRY',
                   i18n: 'providing_country',

--- a/config/edm/rights.yml
+++ b/config/edm/rights.yml
@@ -3,53 +3,52 @@
 open:
   cc0:
     pattern: "https?://creativecommons.org/(licenses/)?publicdomain/zero"
-    api_query: "http//creativecommons.org/*publicdomain/zero*"
   cc_by:
-    pattern: "https?//creativecommons.org/licenses/by/"
+    pattern: "https?://creativecommons.org/licenses/by/"
   cc_by_sa:
-    pattern: "https?//creativecommons.org/licenses/by-sa"
+    pattern: "https?://creativecommons.org/licenses/by-sa"
   pdm:
-    pattern: "https?//creativecommons.org/publicdomain/mark"
+    pattern: "https?://creativecommons.org/publicdomain/mark"
     template_license: public
 # Limited re-use / REUSABILITY="restricted"
 restricted:
   cc_by_nc:
-    pattern: "https?//creativecommons.org/licenses/by-nc/"
+    pattern: "https?://creativecommons.org/licenses/by-nc/"
   cc_by_nc_nd:
-    pattern: "https?//creativecommons.org/licenses/by-nc-nd"
+    pattern: "https?://creativecommons.org/licenses/by-nc-nd"
   cc_by_nc_sa:
-    pattern: "https?//creativecommons.org/licenses/by-nc-sa"
+    pattern: "https?://creativecommons.org/licenses/by-nc-sa"
   cc_by_nd:
-    pattern: "https?//creativecommons.org/licenses/by-nd"
+    pattern: "https?://creativecommons.org/licenses/by-nd"
   out_of_copyright_non_commercial:
-    pattern: "https?//www.europeana.eu/rights/out-of-copyright-non-commercial"
+    pattern: "https?://www.europeana.eu/rights/out-of-copyright-non-commercial"
     template_license: OOC
   rs_inc_edu:
-    pattern: "https?//rightsstatements.org/vocab/InC-EDU/*"
+    pattern: "https?://rightsstatements.org/vocab/InC-EDU/*"
   rs_noc_nc:
-    pattern: "https?//rightsstatements.org/vocab/NoC-NC/*"
+    pattern: "https?://rightsstatements.org/vocab/NoC-NC/*"
   rs_noc_oklr:
-    pattern: "https?//rightsstatements.org/vocab/NoC-OKLR/*"
+    pattern: "https?://rightsstatements.org/vocab/NoC-OKLR/*"
 # No re-use / REUSABILITY="permission"
 permission:
   rrfa:
-    pattern: "https?//www.europeana.eu/rights/rr-f"
+    pattern: "https?://www.europeana.eu/rights/rr-f"
     template_license: RR_free
   rrpa:
-    pattern: "https?//www.europeana.eu/rights/rr-p"
+    pattern: "https?://www.europeana.eu/rights/rr-p"
     template_license: RR_paid
   rrra:
-    pattern: "https?//www.europeana.eu/rights/rr-r/"
+    pattern: "https?://www.europeana.eu/rights/rr-r/"
     template_license: RR_restricted
   ucs:
-    pattern: "https?//www.europeana.eu/rights/unknown"
+    pattern: "https?://www.europeana.eu/rights/unknown"
     template_license: unknown
   orphan_work:
-    pattern: "https?//www.europeana.eu/rights/test-orphan"
+    pattern: "https?://www.europeana.eu/rights/test-orphan"
     template_license: orphan
   rs_inc:
-    pattern: "https?//rightsstatements.org/vocab/InC/*"
+    pattern: "https?://rightsstatements.org/vocab/InC/*"
   rs_inc_ow_eu:
-    pattern: "https?//rightsstatements.org/vocab/InC-OW-EU/*"
+    pattern: "https?://rightsstatements.org/vocab/InC-OW-EU/*"
   rs_cne:
-    pattern: "https?//rightsstatements.org/vocab/CNE/*"
+    pattern: "https?://rightsstatements.org/vocab/CNE/*"

--- a/config/edm/rights.yml
+++ b/config/edm/rights.yml
@@ -2,54 +2,54 @@
 # Free re-use / REUSABILITY="open"
 open:
   cc0:
-    pattern: "http://creativecommons.org/(licenses/)?publicdomain/zero"
-    api_query: "http://creativecommons.org/*publicdomain/zero*"
+    pattern: "https?://creativecommons.org/(licenses/)?publicdomain/zero"
+    api_query: "http//creativecommons.org/*publicdomain/zero*"
   cc_by:
-    pattern: "http://creativecommons.org/licenses/by/"
+    pattern: "https?//creativecommons.org/licenses/by/"
   cc_by_sa:
-    pattern: "http://creativecommons.org/licenses/by-sa"
+    pattern: "https?//creativecommons.org/licenses/by-sa"
   pdm:
-    pattern: "http://creativecommons.org/publicdomain/mark"
+    pattern: "https?//creativecommons.org/publicdomain/mark"
     template_license: public
 # Limited re-use / REUSABILITY="restricted"
 restricted:
   cc_by_nc:
-    pattern: "http://creativecommons.org/licenses/by-nc/"
+    pattern: "https?//creativecommons.org/licenses/by-nc/"
   cc_by_nc_nd:
-    pattern: "http://creativecommons.org/licenses/by-nc-nd"
+    pattern: "https?//creativecommons.org/licenses/by-nc-nd"
   cc_by_nc_sa:
-    pattern: "http://creativecommons.org/licenses/by-nc-sa"
+    pattern: "https?//creativecommons.org/licenses/by-nc-sa"
   cc_by_nd:
-    pattern: "http://creativecommons.org/licenses/by-nd"
+    pattern: "https?//creativecommons.org/licenses/by-nd"
   out_of_copyright_non_commercial:
-    pattern: "http://www.europeana.eu/rights/out-of-copyright-non-commercial"
+    pattern: "https?//www.europeana.eu/rights/out-of-copyright-non-commercial"
     template_license: OOC
   rs_inc_edu:
-    pattern: "http://rightsstatements.org/vocab/InC-EDU/*"
+    pattern: "https?//rightsstatements.org/vocab/InC-EDU/*"
   rs_noc_nc:
-    pattern: "http://rightsstatements.org/vocab/NoC-NC/*"
+    pattern: "https?//rightsstatements.org/vocab/NoC-NC/*"
   rs_noc_oklr:
-    pattern: "http://rightsstatements.org/vocab/NoC-OKLR/*"
+    pattern: "https?//rightsstatements.org/vocab/NoC-OKLR/*"
 # No re-use / REUSABILITY="permission"
 permission:
   rrfa:
-    pattern: "http://www.europeana.eu/rights/rr-f"
+    pattern: "https?//www.europeana.eu/rights/rr-f"
     template_license: RR_free
   rrpa:
-    pattern: "http://www.europeana.eu/rights/rr-p"
+    pattern: "https?//www.europeana.eu/rights/rr-p"
     template_license: RR_paid
   rrra:
-    pattern: "http://www.europeana.eu/rights/rr-r/"
+    pattern: "https?//www.europeana.eu/rights/rr-r/"
     template_license: RR_restricted
   ucs:
-    pattern: "http://www.europeana.eu/rights/unknown"
+    pattern: "https?//www.europeana.eu/rights/unknown"
     template_license: unknown
   orphan_work:
-    pattern: "http://www.europeana.eu/rights/test-orphan"
+    pattern: "https?//www.europeana.eu/rights/test-orphan"
     template_license: orphan
   rs_inc:
-    pattern: "http://rightsstatements.org/vocab/InC/*"
+    pattern: "https?//rightsstatements.org/vocab/InC/*"
   rs_inc_ow_eu:
-    pattern: "http://rightsstatements.org/vocab/InC-OW-EU/*"
+    pattern: "https?//rightsstatements.org/vocab/InC-OW-EU/*"
   rs_cne:
-    pattern: "http://rightsstatements.org/vocab/CNE/*"
+    pattern: "https?//rightsstatements.org/vocab/CNE/*"

--- a/spec/models/edm/rights_spec.rb
+++ b/spec/models/edm/rights_spec.rb
@@ -11,14 +11,13 @@ RSpec.describe EDM::Rights do
         expect(subject.id).to eq(:cc_by_sa)
       end
 
-      # Removed https support temporarily
-      # context 'with https schema' do
-      #  let(:rights) { 'https://creativecommons.org/licenses/by-sa/3.0/de/' }
-      #  it 'should be detected' do
-      #    expect(subject).to be_a(described_class)
-      #    expect(subject.id).to eq(:cc_by_sa)
-      #  end
-      # end
+      context 'with https schema' do
+        let(:rights) { 'https://creativecommons.org/licenses/by-sa/3.0/de/' }
+        it 'should be detected' do
+          expect(subject).to be_a(described_class)
+          expect(subject.id).to eq(:cc_by_sa)
+        end
+      end
     end
 
     context 'when rights are not recognised' do


### PR DESCRIPTION
Allow both http:// and https:// for rights statement urls
basically this PR introduces the s? wildcard to all the rights urls that are used. It also makes the conversion of the pattern string more versatile by removing any wildcard elements be it single character [x?] or multi character patterns [(abcdx)?] with [*] so the pattern can be used as an api param.
This PR also adds a reverse lookup from the params, which strips wildcards, so that the facets can be identified properly on search pages.