### PR TITLE
remove feed permissions-from-editors

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -37,12 +37,11 @@ class Ability
     can :dashboard
     can :read, [Banner, BrowseEntry, Collection, DataProvider, Feed, Gallery,
                 HeroImage, Link, MediaObject, Page, Topic, User]
-    can :create, [BrowseEntry, Feed, Gallery]
+    can :create, [BrowseEntry, Gallery]
     can :update, [DataProvider, HeroImage, MediaObject]
     can :update, BrowseEntry.with_permissions_by(@user)
     can :publish, BrowseEntry.with_permissions_by(@user)
     can :unpublish, BrowseEntry.with_permissions_by(@user)
-    can :update, Feed.with_permissions_by(@user)
     can :update, Gallery.with_permissions_by(@user)
     can :publish, Gallery.with_permissions_by(@user)
     can :unpublish, Gallery.with_permissions_by(@user)

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 class Feed < ActiveRecord::Base
   include HasExternalUrls
-  include IsPermissionable
 
   has_and_belongs_to_many :pages
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,8 +14,6 @@ class User < ActiveRecord::Base
                                                                                source_type: 'Page', source: :permissionable
   has_many :permissionable_galleries, class_name: 'Gallery', through: :permissions, source_type: 'Gallery',
                                       source: :permissionable
-  has_many :permissionable_feeds, class_name: 'Feed', through: :permissions, source_type: 'Feed',
-                                  source: :permissionable
   has_many :permissionable_browse_entries, class_name: 'BrowseEntry', through: :permissions, source_type: 'BrowseEntry',
                                            source: :permissionable
 
@@ -45,10 +43,6 @@ class User < ActiveRecord::Base
 
     def permissionable_browse_entry_ids_enum
       BrowseEntry.where(type: nil).map { |permissionable| [permissionable.title, permissionable.id] }
-    end
-
-    def permissionable_feed_ids_enum
-      Feed.all.map { |permissionable| [permissionable.name, permissionable.id] }
     end
   end
 

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -524,9 +524,6 @@ RailsAdmin.config do |config|
         field :permissionable_browse_entry_ids, :enum do
           multiple true
         end
-        field :permissionable_feed_ids, :enum do
-          multiple true
-        end
       end
     end
   end

--- a/spec/fixtures/permissions.yml
+++ b/spec/fixtures/permissions.yml
@@ -10,7 +10,3 @@ editor_fashion_gallery_permission:
   permissionable: fashion_dresses
   permissionable_type: 'Gallery'
   user: editor
-editor_fashion_feed_permission:
-  permissionable: fashion_tumblr
-  permissionable_type: 'Feed'
-  user: editor

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe Ability do
   let(:draft_landing_page) { pages(:draft_landing_page) }
   let(:published_landing_page) { pages(:music_collection) }
   let(:landing_page_with_editor_permissions) { pages(:fashion_collection) }
-  let(:feed_with_editor_permissions) { feeds(:fashion_tumblr) }
   let(:gallery_with_editor_permissions) { galleries(:fashion_dresses) }
   let(:browse_entry_with_editor_permissions) { browse_entries(:paintings_topic) }
 
@@ -72,7 +71,6 @@ RSpec.describe Ability do
     it { is_expected.not_to be_able_to(:manage, User.new) }
 
     it { is_expected.not_to be_able_to(:update, landing_page_with_editor_permissions) }
-    it { is_expected.not_to be_able_to(:update, feed_with_editor_permissions) }
     it { is_expected.not_to be_able_to(:update, gallery_with_editor_permissions) }
     it { is_expected.not_to be_able_to(:update, browse_entry_with_editor_permissions) }
     it { is_expected.not_to be_able_to(:publish, gallery_with_editor_permissions) }
@@ -116,7 +114,7 @@ RSpec.describe Ability do
     it { is_expected.to be_able_to(:create, BrowseEntry.new) }
     it { is_expected.not_to be_able_to(:create, Collection.new) }
     it { is_expected.not_to be_able_to(:create, DataProvider.new) }
-    it { is_expected.to be_able_to(:create, Feed.new) }
+    it { is_expected.not_to be_able_to(:create, Feed.new) }
     it { is_expected.to be_able_to(:create, Gallery.new) }
     it { is_expected.not_to be_able_to(:create, HeroImage.new) }
     it { is_expected.not_to be_able_to(:create, Page.new) }
@@ -143,7 +141,6 @@ RSpec.describe Ability do
     it { is_expected.not_to be_able_to(:update, User.new) }
 
     it { is_expected.to be_able_to(:update, landing_page_with_editor_permissions) }
-    it { is_expected.to be_able_to(:update, feed_with_editor_permissions) }
     it { is_expected.to be_able_to(:update, gallery_with_editor_permissions) }
     it { is_expected.to be_able_to(:update, browse_entry_with_editor_permissions) }
     it { is_expected.to be_able_to(:publish, gallery_with_editor_permissions) }
@@ -183,7 +180,6 @@ RSpec.describe Ability do
     it { is_expected.to be_able_to(:manage, User.new) }
 
     it { is_expected.to be_able_to(:manage, landing_page_with_editor_permissions) }
-    it { is_expected.to be_able_to(:manage, feed_with_editor_permissions) }
     it { is_expected.to be_able_to(:manage, gallery_with_editor_permissions) }
     it { is_expected.to be_able_to(:manage, browse_entry_with_editor_permissions) }
 

--- a/spec/models/feed_spec.rb
+++ b/spec/models/feed_spec.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
-require 'models/concerns/is_permissionable_examples'
 RSpec.describe Feed do
-  it_behaves_like 'permissionable'
-
   it { is_expected.to validate_presence_of(:name) }
   it { is_expected.to validate_uniqueness_of(:name) }
   it { is_expected.to validate_uniqueness_of(:url) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe User do
   it { is_expected.to have_many(:permissions).inverse_of(:user).dependent(:destroy) }
   it { is_expected.to have_many(:permissionable_landing_pages).through(:permissions).class_name('Page') }
   it { is_expected.to have_many(:permissionable_galleries).through(:permissions).class_name('Gallery') }
-  it { is_expected.to have_many(:permissionable_feeds).through(:permissions).class_name('Feed') }
   it { is_expected.to have_many(:permissionable_browse_entries).through(:permissions).class_name('BrowseEntry') }
 
   describe 'included modules' do
@@ -43,12 +42,6 @@ RSpec.describe User do
     let(:permissionable_browse_entries) { BrowseEntry.where(type: nil) }
     subject { described_class.permissionable_browse_entry_ids_enum }
     it { is_expected.to eq(permissionable_browse_entries.map { |entry| [entry.title, entry.id] }) }
-  end
-
-  describe '.permissionable_feed_ids_enum' do
-    let(:permissionable_feeds) { Feed.all }
-    subject { described_class.permissionable_feed_ids_enum }
-    it { is_expected.to eq(permissionable_feeds.map { |feed| [feed.name, feed.id] }) }
   end
 
   describe '#ability' do


### PR DESCRIPTION
This is to remove the permissions of Editors on Feeds, only Administrators should be able to create these.