### PR TITLE
Add #generic_help to RailsAdmin text fields

### DIFF
--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 require 'rails_admin/config/actions/publish'
 require 'rails_admin/config/actions/unpublish'
+require 'rails_admin/config/fields/extensions/generic_help'
+
+RailsAdmin::Config::Fields::Types::Text.send(:include, RailsAdmin::Config::Fields::Extensions::GenericHelp)
 
 RailsAdmin.config do |config|
   config.main_app_name = ['Europeana Collections']

--- a/lib/rails_admin/config/fields/extensions/generic_help.rb
+++ b/lib/rails_admin/config/fields/extensions/generic_help.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+module RailsAdmin
+  module Config
+    module Fields
+      module Extensions
+        ##
+        # This just duplicates the `#generic_help` method from
+        # `RailsAdmin::Config::Fields::Types::String` to be mixed in to
+        # `RailsAdmin::Config::Fields::Types::Text`.
+        #
+        # @todo suggest to RailsAdmin devs that this method be included in
+        #   `RailsAdmin::Config::Fields::Types::Text`
+        module GenericHelp
+          def generic_help
+            text = (required? ? I18n.translate('admin.form.required') : I18n.translate('admin.form.optional')) + '. '
+            if valid_length.present? && valid_length[:is].present?
+              text += "#{I18n.translate('admin.form.char_length_of').capitalize} #{valid_length[:is]}."
+            else
+              max_length = [length, valid_length[:maximum] || nil].compact.min
+              min_length = [0, valid_length[:minimum] || nil].compact.max
+              if max_length
+                text +=
+                  if min_length == 0
+                    "#{I18n.translate('admin.form.char_length_up_to').capitalize} #{max_length}."
+                  else
+                    "#{I18n.translate('admin.form.char_length_of').capitalize} #{min_length}-#{max_length}."
+                  end
+              end
+            end
+            text
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rails_admin/config/fields/extensions/generic_help.rb
+++ b/lib/rails_admin/config/fields/extensions/generic_help.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:disable all
 module RailsAdmin
   module Config
     module Fields
@@ -28,9 +29,11 @@ module RailsAdmin
               end
             end
             text
+
           end
         end
       end
     end
   end
 end
+# rubocop:enable all

--- a/spec/config/initializers/rails_admin_spec.rb
+++ b/spec/config/initializers/rails_admin_spec.rb
@@ -30,4 +30,8 @@ RSpec.describe RailsAdmin.config do
       end
     end
   end
+
+  it 'adds generic help to text fields' do
+    expect(RailsAdmin::Config::Fields::Types::Text.instance_methods).to include(:generic_help)
+  end
 end


### PR DESCRIPTION
For max length from ActiveModel validations.

Max length hint on string fields comes from: https://github.com/sferik/rails_admin/blob/master/lib/rails_admin/config/fields/types/string.rb#L22-L39

No equivalent on text fields: https://github.com/sferik/rails_admin/blob/master/lib/rails_admin/config/fields/types/text.rb

This PR duplicates the code for the `#generic_help` method on the former and injects it into the latter.

Style violations in the duplicated method will not be fixed here.