### PR TITLE
Events from Pro via JSON API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'rails', '4.2.7.1'
 
 # NB: this *must* be by Git ref; else will break asset versioning in
 #     config/initializers/assets.rb, preventing app startup
-gem 'europeana-styleguide', github: 'europeana/europeana-styleguide-ruby', ref: '1dfb8e0'
+gem 'europeana-styleguide', github: 'europeana/europeana-styleguide-ruby', ref: 'abdd475'
 
 # Use a forked version of stache with downstream changes, until merged upstream
 # @see https://github.com/agoragames/stache/pulls/rwd

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,8 +24,8 @@ GIT
 
 GIT
   remote: git://github.com/europeana/europeana-styleguide-ruby.git
-  revision: 1dfb8e0b9eb32b6a684ac6a354b787e2628ccfe2
-  ref: 1dfb8e0
+  revision: abdd47525629a11aa8c55d2c509373dba76c76b8
+  ref: abdd475
   specs:
     europeana-styleguide (0.2.0)
       activesupport (~> 4.0)

--- a/app/controllers/blog_posts_controller.rb
+++ b/app/controllers/blog_posts_controller.rb
@@ -4,14 +4,14 @@
 # JSON API.
 #
 # @todo Exception handling when `JsonApiClient` requests fail
-# @todo Extract pagination into a controller concern
 class BlogPostsController < ApplicationController
   include HomepageHeroImage
+  include PaginatedController
+
+  self.pagination_per_default = 6
 
   def index
-    @pagination_page = blog_posts_page
-    @pagination_per = blog_posts_per
-    @blog_posts = pro_blog_posts.page(@pagination_page).per(@pagination_per).all
+    @blog_posts = pro_blog_posts.page(pagination_page).per(pagination_per).all
     @hero_image = homepage_hero_image
   end
 
@@ -23,13 +23,5 @@ class BlogPostsController < ApplicationController
 
   def pro_blog_posts
     Pro::BlogPost.includes(:network, :persons)
-  end
-
-  def blog_posts_page
-    (params[:page] || 1).to_i
-  end
-
-  def blog_posts_per
-    (params[:per_page] || 6).to_i
   end
 end

--- a/app/controllers/concerns/paginated_controller.rb
+++ b/app/controllers/concerns/paginated_controller.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+##
+# Methods for controllers requiring pagination
+module PaginatedController
+  extend ActiveSupport::Concern
+
+  class_methods do
+    attr_accessor :pagination_per_default
+  end
+
+  included do
+    self.pagination_per_default ||= 12
+    helper_method :pagination_page, :pagination_per
+  end
+
+  def pagination_page
+    (params[:page] || 1).to_i
+  end
+
+  def pagination_per
+    (params[:per_page] || self.class.pagination_per_default).to_i
+  end
+end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -4,12 +4,13 @@
 # JSON API.
 #
 # @todo Exception handling when `JsonApiClient` requests fail
-# @todo Extract pagination into a controller concern
 class EventsController < ApplicationController
+  include PaginatedController
+
+  self.pagination_per_default = 6
+
   def index
-    @pagination_page = events_page
-    @pagination_per = events_per
-    @events = pro_events.page(@pagination_page).per(@pagination_per).all
+    @events = pro_events.page(pagination_page).per(pagination_per).all
   end
 
   def show
@@ -20,13 +21,5 @@ class EventsController < ApplicationController
 
   def pro_events
     Pro::Event.includes(:network, :persons)
-  end
-
-  def events_page
-    (params[:page] || 1).to_i
-  end
-
-  def events_per
-    (params[:per_page] || 6).to_i
   end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+##
+# Handles listing and display of events retrieved from Europeana Pro via
+# JSON API.
+#
+# @todo Exception handling when `JsonApiClient` requests fail
+# @todo Extract pagination into a controller concern
+class EventsController < ApplicationController
+  def index
+    @pagination_page = events_page
+    @pagination_per = events_per
+    @events = pro_events.page(@pagination_page).per(@pagination_per).all
+  end
+
+  def show
+    @event = pro_events.where(slug: params[:slug]).first
+  end
+
+  protected
+
+  def pro_events
+    Pro::Event.includes(:network, :persons)
+  end
+
+  def events_page
+    (params[:page] || 1).to_i
+  end
+
+  def events_per
+    (params[:per_page] || 6).to_i
+  end
+end

--- a/app/controllers/galleries_controller.rb
+++ b/app/controllers/galleries_controller.rb
@@ -2,12 +2,15 @@
 class GalleriesController < ApplicationController
   include CacheHelper
   include HomepageHeroImage
+  include PaginatedController
+
+  self.pagination_per_default = 24
 
   attr_reader :body_cache_key
 
   def index
     @galleries = Gallery.includes(:images).published.order(published_at: :desc).
-                 page(gallery_page).per(gallery_per).with_topic(gallery_topic)
+                 page(pagination_page).per(pagination_per).with_topic(gallery_topic)
     @selected_topic = gallery_topic
     images = gallery_images_for_foyer(@galleries)
     @hero_image = homepage_hero_image
@@ -72,14 +75,6 @@ class GalleriesController < ApplicationController
 
   def search_api_query_for_images(images)
     'europeana_id:("' + images.map(&:europeana_record_id).join('" OR "') + '")'
-  end
-
-  def gallery_page
-    (params[:page] || 1).to_i
-  end
-
-  def gallery_per
-    (params[:per_page] || 24).to_i
   end
 
   def gallery_topic

--- a/app/models/pro/base.rb
+++ b/app/models/pro/base.rb
@@ -6,6 +6,10 @@ module Pro
   class Base < JsonApiClient::Resource
     self.site = Pro.site + '/json/'
 
+    def to_param
+      respond_to?(:slug) ? slug : nil
+    end
+
     def url
       [Pro.site, self.class.table_name, slug].join('/')
     end

--- a/app/models/pro/blog_post.rb
+++ b/app/models/pro/blog_post.rb
@@ -6,9 +6,5 @@ module Pro
     def self.table_name
       'blogposts'
     end
-
-    def to_param
-      slug
-    end
   end
 end

--- a/app/models/pro/event.rb
+++ b/app/models/pro/event.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+module Pro
+  ##
+  # Events from Pro JSON API.
+  class Event < Base
+  end
+end

--- a/app/views/blog_posts/index.rb
+++ b/app/views/blog_posts/index.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module BlogPosts
   class Index < ApplicationView
-    include PaginatedView
+    include PaginatedJsonApiResultSetView
 
     def page_title
       mustache[:page_title] ||= begin
@@ -49,47 +49,6 @@ module BlogPosts
 
     def paginated_set
       @blog_posts
-    end
-
-    def pagination_current_page
-      mustache[:pagination_current_page] ||= begin
-        # JsonApiClient::ResultSet#current_page always returns 1 here for some reason
-        # @blog_posts.current_page
-
-        # Get it out of the controller-assigned var instead
-        @pagination_page
-      end
-    end
-
-    def pagination_per_page
-      mustache[:pagination_per_page] ||= begin
-        # JsonApiClient::ResultSet#per_page always returns number in this page
-        # here for some reason
-        # @blog_posts.per_page
-
-        # Get it out of the controller-assigned var instead
-        @pagination_per
-      end
-    end
-
-    def pagination_total
-      # JsonApiClient::ResultSet#total_count always returns number in this page
-      # here for some reason
-      # @blog_posts.total_pages
-      if @blog_posts.respond_to?(:meta) && @blog_posts.meta.respond_to?(:total)
-        @blog_posts.meta.total
-      else
-        0
-      end
-    end
-
-    def pagination_total_pages
-      mustache[:pagination_total_pages] ||= begin
-        # JsonApiClient::ResultSet#total_pages always returns 1 here for some reason
-        # @blog_posts.total_pages
-        (pagination_total / pagination_per_page) +
-          ((pagination_total / pagination_per_page).zero? ? 0 : 1)
-      end
     end
   end
 end

--- a/app/views/concerns/paginated_json_api_result_set_view.rb
+++ b/app/views/concerns/paginated_json_api_result_set_view.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+##
+# Pagination of JSON API result sets
+#
+# Including views need to implement `paginated_set`.
+module PaginatedJsonApiResultSetView
+  extend ActiveSupport::Concern
+  include PaginatedView
+
+  protected
+
+  def pagination_current_page
+    mustache[:pagination_current_page] ||= begin
+      # JsonApiClient::ResultSet#current_page always returns 1 with
+      # `paginated_set.current_page`
+
+      # Get it out of the controller-assigned var instead
+      @pagination_page
+    end
+  end
+
+  def pagination_per_page
+    mustache[:pagination_per_page] ||= begin
+      # JsonApiClient::ResultSet#per_page always returns number in *this* page
+      # with `paginated_set.per_page`
+
+      # Get it out of the controller-assigned var instead
+      @pagination_per
+    end
+  end
+
+  def pagination_total
+    mustache[:pagination_total] ||= begin
+      # JsonApiClient::ResultSet#total_count always returns number in *this* page
+      # with `paginated_set.total_pages`
+
+      # Get it from JSON API meta data instead
+      if paginated_set.respond_to?(:meta) && paginated_set.meta.respond_to?(:total)
+        paginated_set.meta.total
+      else
+        0
+      end
+    end
+  end
+
+  def pagination_total_pages
+    mustache[:pagination_total_pages] ||= begin
+      # JsonApiClient::ResultSet#total_pages always returns 1 with
+      # `paginated_set.total_pages`
+
+      # Calculate it ourselves instead
+      (pagination_total / pagination_per_page) +
+        ((pagination_total / pagination_per_page).zero? ? 0 : 1)
+    end
+  end
+end

--- a/app/views/concerns/paginated_json_api_result_set_view.rb
+++ b/app/views/concerns/paginated_json_api_result_set_view.rb
@@ -14,8 +14,8 @@ module PaginatedJsonApiResultSetView
       # JsonApiClient::ResultSet#current_page always returns 1 with
       # `paginated_set.current_page`
 
-      # Get it out of the controller-assigned var instead
-      @pagination_page
+      # Get it out of the controller instead
+      pagination_page
     end
   end
 
@@ -24,8 +24,8 @@ module PaginatedJsonApiResultSetView
       # JsonApiClient::ResultSet#per_page always returns number in *this* page
       # with `paginated_set.per_page`
 
-      # Get it out of the controller-assigned var instead
-      @pagination_per
+      # Get it out of the controller instead
+      pagination_per
     end
   end
 

--- a/app/views/events/index.html.mustache
+++ b/app/views/events/index.html.mustache
@@ -1,0 +1,3 @@
+{{>atoms/meta/_head}}
+  {{>templates/Search/Search-static-page}}
+{{>atoms/meta/_foot}}

--- a/app/views/events/index.rb
+++ b/app/views/events/index.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+module Events
+  class Index < ApplicationView
+    include PaginatedJsonApiResultSetView
+
+    def page_title
+      mustache[:page_title] ||= begin
+        [t('site.events.list.page-title'), site_title].join(' - ')
+      end
+    end
+
+    def navigation
+      mustache[:navigation] ||= begin
+        {
+          pagination: pagination_navigation
+        }.reverse_merge(super)
+      end
+    end
+
+    def content
+      mustache[:content] ||= begin
+        {
+          title: t('site.events.list.page-title'),
+          text: '<ol>' + @events.map { |event| '<li>' + link_to(event.title, event_path(event)) + '</li>' }.join + '</ol>'
+        }.reverse_merge(super)
+      end
+    end
+
+    protected
+
+    def paginated_set
+      @events
+    end
+  end
+end

--- a/app/views/events/show.html.mustache
+++ b/app/views/events/show.html.mustache
@@ -1,0 +1,3 @@
+{{>atoms/meta/_head}}
+  {{>templates/Search/Search-static-page}}
+{{>atoms/meta/_foot}}

--- a/app/views/events/show.rb
+++ b/app/views/events/show.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+module Events
+  class Show < ApplicationView
+    def page_title
+      mustache[:page_title] ||= [@event.title, site_title].join(' - ')
+    end
+
+    def content
+      mustache[:content] ||= begin
+        {
+          title: @event.title,
+          text: @event.introduction + @event.body
+        }.reverse_merge(super)
+      end
+    end
+
+    def navigation
+      mustache[:navigation] ||= begin
+        {
+          back_url: events_path,
+          back_label: t('site.events.list.page-title')
+        }.reverse_merge(super)
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,6 +56,7 @@ Rails.application.routes.draw do
     end
 
     resources :blog_posts, only: [:show, :index], param: :slug, path: 'blogs'
+    resources :events, only: [:show, :index], param: :slug
 
     get 'entities/suggest'
 

--- a/spec/controllers/blog_posts_controller_spec.rb
+++ b/spec/controllers/blog_posts_controller_spec.rb
@@ -1,53 +1,59 @@
 # frozen_string_literal: true
 RSpec.describe BlogPostsController do
-  JSON_API_URL = %r{\A#{Rails.application.config.x.europeana[:pro_url]}/json/blogposts(\?|\z)}
-  JSON_API_CONTENT_TYPE = 'application/vnd.api+json'
+  let(:json_api_url) { %r{\A#{Rails.application.config.x.europeana[:pro_url]}/json/blogposts(\?|\z)} }
+  let(:json_api_content_type) { 'application/vnd.api+json' }
 
   before do
-    stub_request(:get, JSON_API_URL).
+    stub_request(:get, json_api_url).
       with(headers: {
-             'Accept' => JSON_API_CONTENT_TYPE,
-             'Content-Type' => JSON_API_CONTENT_TYPE
+             'Accept' => json_api_content_type,
+             'Content-Type' => json_api_content_type
            }).
       to_return(
         status: 200,
         body: '{"meta": {"count": 0, "total": 0}, "data":[]}',
-        headers: { 'Content-Type' => JSON_API_CONTENT_TYPE }
+        headers: { 'Content-Type' => json_api_content_type }
       )
+  end
+
+  describe 'concerns' do
+    subject { described_class }
+    it { is_expected.to include(HomepageHeroImage) }
+    it { is_expected.to include(PaginatedController) }
   end
 
   describe 'GET #index' do
     it 'queries the Pro JSON-API for 6 posts' do
       get :index, locale: 'en'
       expect(
-        a_request(:get, JSON_API_URL)
+        a_request(:get, json_api_url)
       ).to have_been_made.once
     end
 
     it 'requests 6 blog posts' do
       get :index, locale: 'en'
       expect(
-        a_request(:get, JSON_API_URL).
+        a_request(:get, json_api_url).
         with(query: hash_including(page: { number: '1', size: '6' }))
       ).to have_been_made.once
-      expect(assigns(:pagination_per)).to eq(6)
-      expect(assigns(:pagination_page)).to eq(1)
+      expect(controller.pagination_per).to eq(6)
+      expect(controller.pagination_page).to eq(1)
     end
 
     it 'requests the page in `page` param' do
       get :index, locale: 'en', page: 3
       expect(
-        a_request(:get, JSON_API_URL).
+        a_request(:get, json_api_url).
         with(query: hash_including(page: { number: '3', size: '6' }))
       ).to have_been_made.once
-      expect(assigns(:pagination_per)).to eq(6)
-      expect(assigns(:pagination_page)).to eq(3)
+      expect(controller.pagination_per).to eq(6)
+      expect(controller.pagination_page).to eq(3)
     end
 
     it 'includes related resources' do
       get :index, locale: 'en'
       expect(
-        a_request(:get, JSON_API_URL).
+        a_request(:get, json_api_url).
         with(query: hash_including(include: 'network,persons'))
       ).to have_been_made.once
     end
@@ -74,7 +80,7 @@ RSpec.describe BlogPostsController do
     it 'queries the Pro JSON-API for the post' do
       get :show, locale: 'en', slug: 'important-news'
       expect(
-        a_request(:get, JSON_API_URL).
+        a_request(:get, json_api_url).
         with(query: hash_including(filter: { slug: 'important-news' }, page: { number: '1', size: '1' }))
       ).to have_been_made.once
     end
@@ -82,7 +88,7 @@ RSpec.describe BlogPostsController do
     it 'includes related resources' do
       get :show, locale: 'en', slug: 'important-news'
       expect(
-        a_request(:get, JSON_API_URL).
+        a_request(:get, json_api_url).
         with(query: hash_including(include: 'network,persons'))
       ).to have_been_made.once
     end

--- a/spec/controllers/concerns/paginated_controller_spec.rb
+++ b/spec/controllers/concerns/paginated_controller_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+RSpec.describe PaginatedController do
+  let(:controller_class) do
+    Class.new(ApplicationController) do
+      include PaginatedController
+    end
+  end
+
+  let(:controller_params) { {} }
+
+  subject { controller_class.new }
+
+  before do
+    allow(subject).to receive(:params) { controller_params }
+  end
+
+  describe '.pagination_per_default' do
+    it 'defaults to 12' do
+      expect(subject.class.pagination_per_default).to eq(12)
+    end
+  end
+
+  describe '#pagination_page' do
+    context 'with :page in params' do
+      let(:controller_params) { { page: '77' } }
+
+      it 'returns :page param as integer' do
+        expect(subject.pagination_page).to eq(77)
+      end
+    end
+
+    context 'without :page in params' do
+      it 'returns 1' do
+        expect(subject.pagination_page).to eq(1)
+      end
+    end
+  end
+
+  describe '#pagination_per' do
+    context 'with :per_page in params' do
+      let(:controller_params) { { per_page: '48' } }
+
+      it 'returns :per_page param as integer' do
+        expect(subject.pagination_per).to eq(48)
+      end
+    end
+
+    context 'without :per_page in params' do
+      it 'returns `.pagination_per_default`' do
+        expect(subject.pagination_per).to eq(12)
+      end
+    end
+  end
+end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -1,53 +1,58 @@
 # frozen_string_literal: true
 RSpec.describe EventsController do
-  JSON_API_URL = %r{\A#{Rails.application.config.x.europeana[:pro_url]}/json/events(\?|\z)}
-  JSON_API_CONTENT_TYPE = 'application/vnd.api+json'
+  let(:json_api_url) { %r{\A#{Rails.application.config.x.europeana[:pro_url]}/json/events(\?|\z)} }
+  let(:json_api_content_type) { 'application/vnd.api+json' }
 
   before do
-    stub_request(:get, JSON_API_URL).
+    stub_request(:get, json_api_url).
       with(headers: {
-             'Accept' => JSON_API_CONTENT_TYPE,
-             'Content-Type' => JSON_API_CONTENT_TYPE
+             'Accept' => json_api_content_type,
+             'Content-Type' => json_api_content_type
            }).
       to_return(
         status: 200,
         body: '{"meta": {"count": 0, "total": 0}, "data":[]}',
-        headers: { 'Content-Type' => JSON_API_CONTENT_TYPE }
+        headers: { 'Content-Type' => json_api_content_type }
       )
+  end
+
+  describe 'concerns' do
+    subject { described_class }
+    it { is_expected.to include(PaginatedController) }
   end
 
   describe 'GET #index' do
     it 'queries the Pro JSON-API for 6 posts' do
       get :index, locale: 'en'
       expect(
-        a_request(:get, JSON_API_URL)
+        a_request(:get, json_api_url)
       ).to have_been_made.once
     end
 
     it 'requests 6 event posts' do
       get :index, locale: 'en'
       expect(
-        a_request(:get, JSON_API_URL).
+        a_request(:get, json_api_url).
         with(query: hash_including(page: { number: '1', size: '6' }))
       ).to have_been_made.once
-      expect(assigns(:pagination_per)).to eq(6)
-      expect(assigns(:pagination_page)).to eq(1)
+      expect(controller.pagination_per).to eq(6)
+      expect(controller.pagination_page).to eq(1)
     end
 
     it 'requests the page in `page` param' do
       get :index, locale: 'en', page: 3
       expect(
-        a_request(:get, JSON_API_URL).
+        a_request(:get, json_api_url).
         with(query: hash_including(page: { number: '3', size: '6' }))
       ).to have_been_made.once
-      expect(assigns(:pagination_per)).to eq(6)
-      expect(assigns(:pagination_page)).to eq(3)
+      expect(controller.pagination_per).to eq(6)
+      expect(controller.pagination_page).to eq(3)
     end
 
     it 'includes related resources' do
       get :index, locale: 'en'
       expect(
-        a_request(:get, JSON_API_URL).
+        a_request(:get, json_api_url).
         with(query: hash_including(include: 'network,persons'))
       ).to have_been_made.once
     end
@@ -74,7 +79,7 @@ RSpec.describe EventsController do
     it 'queries the Pro JSON-API for the post' do
       get :show, locale: 'en', slug: 'conference'
       expect(
-        a_request(:get, JSON_API_URL).
+        a_request(:get, json_api_url).
         with(query: hash_including(filter: { slug: 'conference' }, page: { number: '1', size: '1' }))
       ).to have_been_made.once
     end
@@ -82,7 +87,7 @@ RSpec.describe EventsController do
     it 'includes related resources' do
       get :show, locale: 'en', slug: 'conference'
       expect(
-        a_request(:get, JSON_API_URL).
+        a_request(:get, json_api_url).
         with(query: hash_including(include: 'network,persons'))
       ).to have_been_made.once
     end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+RSpec.describe EventsController do
+  JSON_API_URL = %r{\A#{Rails.application.config.x.europeana[:pro_url]}/json/events(\?|\z)}
+  JSON_API_CONTENT_TYPE = 'application/vnd.api+json'
+
+  before do
+    stub_request(:get, JSON_API_URL).
+      with(headers: {
+             'Accept' => JSON_API_CONTENT_TYPE,
+             'Content-Type' => JSON_API_CONTENT_TYPE
+           }).
+      to_return(
+        status: 200,
+        body: '{"meta": {"count": 0, "total": 0}, "data":[]}',
+        headers: { 'Content-Type' => JSON_API_CONTENT_TYPE }
+      )
+  end
+
+  describe 'GET #index' do
+    it 'queries the Pro JSON-API for 6 posts' do
+      get :index, locale: 'en'
+      expect(
+        a_request(:get, JSON_API_URL)
+      ).to have_been_made.once
+    end
+
+    it 'requests 6 event posts' do
+      get :index, locale: 'en'
+      expect(
+        a_request(:get, JSON_API_URL).
+        with(query: hash_including(page: { number: '1', size: '6' }))
+      ).to have_been_made.once
+      expect(assigns(:pagination_per)).to eq(6)
+      expect(assigns(:pagination_page)).to eq(1)
+    end
+
+    it 'requests the page in `page` param' do
+      get :index, locale: 'en', page: 3
+      expect(
+        a_request(:get, JSON_API_URL).
+        with(query: hash_including(page: { number: '3', size: '6' }))
+      ).to have_been_made.once
+      expect(assigns(:pagination_per)).to eq(6)
+      expect(assigns(:pagination_page)).to eq(3)
+    end
+
+    it 'includes related resources' do
+      get :index, locale: 'en'
+      expect(
+        a_request(:get, JSON_API_URL).
+        with(query: hash_including(include: 'network,persons'))
+      ).to have_been_made.once
+    end
+
+    it 'returns http success' do
+      get :index, locale: 'en'
+      expect(response).to have_http_status(:success)
+    end
+
+    it 'assigns result set to @events' do
+      get :index, locale: 'en'
+      expect(assigns(:events)).to be_a(JsonApiClient::ResultSet)
+    end
+
+    it 'defaults to HTML format' do
+      get :index, locale: 'en'
+      expect(response.content_type).to eq('text/html')
+    end
+
+    it 'does not respond to .json format' # or should it, just outputting the JSON-API response?
+  end
+
+  describe 'GET #show' do
+    it 'queries the Pro JSON-API for the post' do
+      get :show, locale: 'en', slug: 'conference'
+      expect(
+        a_request(:get, JSON_API_URL).
+        with(query: hash_including(filter: { slug: 'conference' }, page: { number: '1', size: '1' }))
+      ).to have_been_made.once
+    end
+
+    it 'includes related resources' do
+      get :show, locale: 'en', slug: 'conference'
+      expect(
+        a_request(:get, JSON_API_URL).
+        with(query: hash_including(include: 'network,persons'))
+      ).to have_been_made.once
+    end
+
+    it 'returns http success' do
+      get :show, locale: 'en', slug: 'conference'
+      expect(response).to have_http_status(:success)
+    end
+
+    it 'defaults to HTML format' do
+      get :show, locale: 'en', slug: 'conference'
+      expect(response.content_type).to eq('text/html')
+    end
+  end
+end

--- a/spec/controllers/galleries_controller_spec.rb
+++ b/spec/controllers/galleries_controller_spec.rb
@@ -1,5 +1,12 @@
 # frozen_string_literal: true
 RSpec.describe GalleriesController do
+  describe 'concerns' do
+    subject { described_class }
+    it { is_expected.to include(CacheHelper) }
+    it { is_expected.to include(HomepageHeroImage) }
+    it { is_expected.to include(PaginatedController) }
+  end
+
   describe 'GET #index' do
     it 'returns http success' do
       get :index, locale: 'en'

--- a/spec/models/pro/base_spec.rb
+++ b/spec/models/pro/base_spec.rb
@@ -7,4 +7,28 @@ RSpec.describe Pro::Base do
       expect(described_class.site).to eq(%(#{Pro.site}/json/))
     end
   end
+
+  describe '#to_param' do
+    before do
+      class Pro::Base::TestSubclass < Pro::Base; end
+    end
+    let(:subclass) { Pro::Base::TestSubclass }
+    subject { subclass.new }
+
+    context 'when resource has slug attr' do
+      before do
+        subject.attributes['slug'] = 'pellet'
+      end
+
+      it 'returns slug' do
+        expect(subject.to_param).to eq('pellet')
+      end
+    end
+
+    context 'when resource has no slug attr' do
+      it 'is nil' do
+        expect(subject.to_param).to be_nil
+      end
+    end
+  end
 end

--- a/spec/models/pro/base_spec.rb
+++ b/spec/models/pro/base_spec.rb
@@ -10,9 +10,11 @@ RSpec.describe Pro::Base do
 
   describe '#to_param' do
     before do
-      class Pro::Base::TestSubclass < Pro::Base; end
+      module Pro
+        class TestSubclass < Pro::Base; end
+      end
     end
-    let(:subclass) { Pro::Base::TestSubclass }
+    let(:subclass) { Pro::TestSubclass }
     subject { subclass.new }
 
     context 'when resource has slug attr' do

--- a/spec/models/pro/event_spec.rb
+++ b/spec/models/pro/event_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+RSpec.describe Pro::Event do
+  it { is_expected.to be_a(Pro::Base) }
+
+  describe '.table_name' do
+    subject { described_class.table_name }
+    it { is_expected.to eq('events') }
+  end
+end

--- a/spec/routing/events_routing_spec.rb
+++ b/spec/routing/events_routing_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+RSpec.describe 'routes for the events controller' do
+  it 'routes GET /en/events to events#index' do
+    expect(get('/en/events')).to route_to('events#index', locale: 'en')
+  end
+
+  it 'routes GET /en/events/conference to events#show' do
+    expect(get('/en/events/conference')).to route_to('events#show', locale: 'en', slug: 'conference')
+  end
+end

--- a/spec/views/blog_posts/index_spec.rb
+++ b/spec/views/blog_posts/index_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe 'blog_posts/index.html.mustache' do
   end
 
   before do
-    assign(:pagination_page, pagination_page)
-    assign(:pagination_per, pagination_per)
+    allow(view).to receive(:pagination_page) { pagination_page }
+    allow(view).to receive(:pagination_per) { pagination_per }
     assign(:blog_posts, blog_posts)
   end
 


### PR DESCRIPTION
Initial implementation of events retrieval from Pro site's JSON API.

* Views show some basic data as a POC; full population pending template implementation
* Pagination of JSON API result sets extracted into a new view concern
* Pagination in controllers extracted into a controller concern, but not applied to `PortalController` as that has multiple actions paginating different result sets, plus Blacklight handles pagination for `#index`