### PR TITLE
Update Nokogiri to 1.7.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem 'json_api_client'
 gem 'lograge'
 gem 'logstash-event'
 gem 'logstash-logger'
-gem 'nokogiri', '~> 1.6.8'
+gem 'nokogiri'
 gem 'redis', '3.3.1' # locked to fix: https://app.assembla.com/spaces/europeana-npc/tickets/1811
 gem 'rest-client', '~> 1.8.0'
 gem 'ruby-oembed', '~> 0.9'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -394,7 +394,7 @@ GEM
     nested_form (0.3.2)
     netrc (0.11.0)
     newrelic_rpm (3.18.1.330)
-    nokogiri (1.6.8.1)
+    nokogiri (1.7.1)
       mini_portile2 (~> 2.1.0)
     orm_adapter (0.5.0)
     paper_trail (4.2.0)
@@ -644,7 +644,7 @@ DEPENDENCIES
   logstash-event
   logstash-logger
   newrelic_rpm
-  nokogiri (~> 1.6.8)
+  nokogiri
   paper_trail (~> 4.0)
   paperclip (~> 4.3)
   pg


### PR DESCRIPTION
Re CVE-2016-4658

But unlocked in the Gemfile for easier future updating.