### PR TITLE
Get gallery thumbnails straight from S3

### DIFF
--- a/app/helpers/record_helper.rb
+++ b/app/helpers/record_helper.rb
@@ -60,19 +60,19 @@ module RecordHelper
   end
 
   # temporary fix until API contains correct image url
-  def record_preview_url(edm_preview, size = 200)
+  def record_preview_url(edm_preview, size = 200, source = :api)
     return edm_preview if edm_preview.nil?
 
-    # From the thumbnails API
-    # edm_preview.tap do |preview|
-    #   preview.sub!('http://europeanastatic.eu/api/image?', api_url + '/v2/thumbnail-by-url.json?')
-    #   preview.sub!('&size=LARGE', "&size=w#{size}")
-    # end
-
-    # From S3
-    uri = CGI.parse(URI.parse(edm_preview).query)['uri'].first
-    resource_size = size == 400 ? 'LARGE' : 'MEDIUM'
-    resource_path = Digest::MD5.hexdigest(uri) + '-' + resource_size
-    resource_url = 'https://europeana-thumbnails-production.s3.amazonaws.com/' + resource_path
+    if source == :s3
+      uri = CGI.parse(URI.parse(edm_preview).query)['uri'].first
+      resource_size = size == 400 ? 'LARGE' : 'MEDIUM'
+      resource_path = Digest::MD5.hexdigest(uri) + '-' + resource_size
+      'https://europeana-thumbnails-production.s3.amazonaws.com/' + resource_path
+    else
+      edm_preview.tap do |preview|
+        preview.sub!('http://europeanastatic.eu/api/image?', api_url + '/v2/thumbnail-by-url.json?')
+        preview.sub!('&size=LARGE', "&size=w#{size}")
+      end
+    end
   end
 end

--- a/app/helpers/record_helper.rb
+++ b/app/helpers/record_helper.rb
@@ -62,9 +62,17 @@ module RecordHelper
   # temporary fix until API contains correct image url
   def record_preview_url(edm_preview, size = 200)
     return edm_preview if edm_preview.nil?
-    edm_preview.tap do |preview|
-      preview.sub!('http://europeanastatic.eu/api/image?', api_url + '/v2/thumbnail-by-url.json?')
-      preview.sub!('&size=LARGE', "&size=w#{size}")
-    end
+
+    # From the thumbnails API
+    # edm_preview.tap do |preview|
+    #   preview.sub!('http://europeanastatic.eu/api/image?', api_url + '/v2/thumbnail-by-url.json?')
+    #   preview.sub!('&size=LARGE', "&size=w#{size}")
+    # end
+
+    # From S3
+    uri = CGI.parse(URI.parse(edm_preview).query)['uri'].first
+    resource_size = size == 400 ? 'LARGE' : 'MEDIUM'
+    resource_path = Digest::MD5.hexdigest(uri) + '-' + resource_size
+    resource_url = 'https://europeana-thumbnails-production.s3.amazonaws.com/' + resource_path
   end
 end

--- a/app/views/concerns/gallery_displaying_view.rb
+++ b/app/views/concerns/gallery_displaying_view.rb
@@ -10,7 +10,7 @@ module GalleryDisplayingView
     presenter = presenter_for_gallery_image(image)
     return nil if presenter.nil?
     edm_preview = presenter.field_value('edmPreview')
-    record_preview_url(edm_preview, 400)
+    record_preview_url(edm_preview, 400, :s3)
   end
 
   def presenter_for_gallery_image(image)

--- a/spec/fixtures/api_response/search.json.erb
+++ b/spec/fixtures/api_response/search.json.erb
@@ -1,7 +1,8 @@
 <%
 items = (0..20).map do |index|
   id = '/sample/record' + index.to_s
-  '{"id":"' + id + '","title":["' + id + '"],"edmIsShownBy":["providerurl' + id + '"],"edmPreview":["thumbnail_url' + id + '"]}'
+  edm_preview = 'http://europeanastatic.eu/api/image?uri=' + CGI.escape("http://www.example.com#{id}") + '&size=LARGE&type=TEXT'
+  '{"id":"' + id + '","title":["' + id + '"],"edmIsShownBy":["providerurl' + id + '"],"edmPreview":["' + edm_preview + '"]}'
 end
 %>
 {


### PR DESCRIPTION
Because the thumbnail API does not perform well enough for many thumbnails on one page.