### PR TITLE
Filtering blog posts and events

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,9 @@
 ## Enable blog posts theme filter [EXPERIMENTAL]
 # ENABLE_BLOG_POSTS_THEME_FILTER=1
 
+## Enable events theme filter [EXPERIMENTAL]
+# ENABLE_EVENTS_THEME_FILTER=1
+
 ## Enable entity autocomplete on search form [EXPERIMENTAL]
 # ENABLE_SEARCH_FORM_AUTOCOMPLETE=1
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'rails', '4.2.7.1'
 
 # NB: this *must* be by Git ref; else will break asset versioning in
 #     config/initializers/assets.rb, preventing app startup
-gem 'europeana-styleguide', github: 'europeana/europeana-styleguide-ruby', ref: '8b0c885'
+gem 'europeana-styleguide', github: 'europeana/europeana-styleguide-ruby', ref: '9a40957'
 
 # Lock Mustache at 1.0.3 because > 1.0.3 kills item page performance with the commit
 # https://github.com/mustache/mustache/commit/3c7af8f33d0c3b04c159e10e73a2831cf1e56e02

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,8 +24,8 @@ GIT
 
 GIT
   remote: git://github.com/europeana/europeana-styleguide-ruby.git
-  revision: 8b0c885600e6f846a29dc3956f8e8c518e706bc2
-  ref: 8b0c885
+  revision: 9a409576ed928625fab8acc5cac5f6959ad62ba0
+  ref: 9a40957
   specs:
     europeana-styleguide (0.2.0)
       activesupport (~> 4.0)

--- a/app/controllers/blog_posts_controller.rb
+++ b/app/controllers/blog_posts_controller.rb
@@ -8,6 +8,7 @@ class BlogPostsController < ApplicationController
   include CacheHelper
   include HomepageHeroImage
   include PaginatedController
+  include ProJsonApiConsumer
 
   self.pagination_per_default = 6
 
@@ -15,12 +16,9 @@ class BlogPostsController < ApplicationController
   helper_method :body_cache_key
 
   def index
-    @blog_posts = Pro::BlogPost.includes(:network).
-                  where(filters).
+    @blog_posts = Pro::BlogPost.includes(:network).where(pro_json_api_filters).
                   page(pagination_page).per(pagination_per).all
     @hero_image = homepage_hero_image
-    @theme_filters = theme_filters
-    @selected_theme = theme
 
     respond_to do |format|
       format.html
@@ -31,7 +29,8 @@ class BlogPostsController < ApplicationController
     @body_cache_key = "blogs/#{params[:slug]}.#{request.format.to_sym}"
 
     unless body_cached?
-      results = Pro::BlogPost.includes(:network).where(filters).where(slug: params[:slug])
+      results = Pro::BlogPost.includes(:network).where(pro_json_api_filters).
+                where(slug: params[:slug])
       @blog_post = results.first
       fail JsonApiClient::Errors::NotFound.new(results.links.links['self']) if @blog_post.nil?
     end
@@ -39,35 +38,5 @@ class BlogPostsController < ApplicationController
     respond_to do |format|
       format.html
     end
-  end
-
-  protected
-
-  def filters
-    {}.tap do |filters|
-      filters[:blogs] = (theme_filters[theme] || {})[:filter]
-      filters[:tags] = tag unless tag.nil?
-    end
-  end
-
-  def theme
-    (params[:theme] || 'all').to_sym
-  end
-
-  def tag
-    params[:tag]
-  end
-
-  def theme_filters
-    {
-      all: {
-        filter: 'europeana-fashion', # comma-separated list of all blogs to include
-        label: t('global.actions.filter-all')
-      },
-      fashion: {
-        filter: 'europeana-fashion',
-        label: Topic.find_by_slug('fashion').label
-      }
-    }
   end
 end

--- a/app/controllers/concerns/pro_json_api_consumer.rb
+++ b/app/controllers/concerns/pro_json_api_consumer.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+module ProJsonApiConsumer
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :assign_pro_json_api_theme_vars, only: :index
+  end
+
+  protected
+
+  def assign_pro_json_api_theme_vars
+    @theme_filters = pro_json_api_theme_filters
+    @selected_theme = pro_json_api_theme
+  end
+
+  def pro_json_api_filters
+    {
+      tags: (pro_json_api_theme_filters[pro_json_api_theme] || {})[:filter]
+    }
+  end
+
+  def pro_json_api_theme
+    (params[:theme] || 'all').to_sym
+  end
+
+  def pro_json_api_theme_filters
+    {
+      all: {
+        filter: 'culturelover',
+        label: t('global.actions.filter-all')
+      },
+      fashion: {
+        filter: 'culturelover-fashion',
+        label: Topic.find_by_slug('fashion').label
+      }
+    }
+  end
+end

--- a/app/controllers/concerns/pro_json_api_consumer.rb
+++ b/app/controllers/concerns/pro_json_api_consumer.rb
@@ -3,23 +3,18 @@ module ProJsonApiConsumer
   extend ActiveSupport::Concern
 
   included do
-    before_action :assign_pro_json_api_theme_vars, only: :index
+    helper_method :pro_json_api_theme_filters, :pro_json_api_selected_theme
   end
 
   protected
 
-  def assign_pro_json_api_theme_vars
-    @theme_filters = pro_json_api_theme_filters
-    @selected_theme = pro_json_api_theme
-  end
-
   def pro_json_api_filters
     {
-      tags: (pro_json_api_theme_filters[pro_json_api_theme] || {})[:filter]
+      tags: (pro_json_api_theme_filters[pro_json_api_selected_theme] || {})[:filter]
     }
   end
 
-  def pro_json_api_theme
+  def pro_json_api_selected_theme
     (params[:theme] || 'all').to_sym
   end
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -11,7 +11,7 @@ class EventsController < ApplicationController
   include PaginatedController
   include ProJsonApiConsumer
 
-  helper_method :order_filters, :selected_order
+  helper_method :past_future_filters, :selected_past_future
 
   self.pagination_per_default = 6
 
@@ -20,7 +20,7 @@ class EventsController < ApplicationController
 
   def index
     @events = Pro::Event.includes(:locations, :network).where(pro_json_api_filters).
-              where(past_future_filter).
+              where(pro_json_api_past_future_filter).
               order('-end_event').page(pagination_page).per(pagination_per).all
     @hero_image = homepage_hero_image
 
@@ -46,17 +46,17 @@ class EventsController < ApplicationController
 
   protected
 
-  def past_future_filter
+  def pro_json_api_past_future_filter
     {
-      end_event: (order_filters[selected_order] || {})[:filter]
+      end_event: (past_future_filters[selected_past_future] || {})[:filter]
     }
   end
 
-  def selected_order
-    (params[:order] || 'future').to_sym
+  def selected_past_future
+    (params[:sort] || 'future').to_sym
   end
 
-  def order_filters
+  def past_future_filters
     date = Date.today.strftime
     {
       future: {

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -8,37 +8,25 @@
 class EventsController < ApplicationController
   include HomepageHeroImage
   include PaginatedController
+  include ProJsonApiConsumer
 
   self.pagination_per_default = 6
 
   def index
-    @events = Pro::Event.includes(:locations, :network).
-              order('-end_event').
-              # Uncomment to restrict to events tagged "culturelover"
-              # where(filters).
+    @events = Pro::Event.includes(:locations, :network).where(pro_json_api_filters).
               # Uncomment to restrict to current and future events, but only
               # when UI is in place to switch to past events, and accommodate
               # that by param in this controller.
               # where(end_event: ">=" + Date.today.strftime).
-              page(pagination_page).per(pagination_per).all
+              order('-end_event').page(pagination_page).per(pagination_per).all
     @hero_image = homepage_hero_image
   end
 
   def show
-    results = Pro::Event.includes(:locations, :network).
-              # Uncomment to restrict to events tagged "culturelover"
-              # where(filters).
+    results = Pro::Event.includes(:locations, :network).where(pro_json_api_filters).
               where(slug: params[:slug])
     @event = results.first
 
     fail JsonApiClient::Errors::NotFound.new(results.links.links['self']) if @event.nil?
-  end
-
-  protected
-
-  def filters
-    {
-      tags: 'culturelover'
-    }
   end
 end

--- a/app/presenters/pro_resource_presenter.rb
+++ b/app/presenters/pro_resource_presenter.rb
@@ -39,12 +39,12 @@ class ProResourcePresenter
 
   # We omit from view internal-use tags starting "culturelover"
   def displayable_tags
-    return nil unless resource.has_taxonomy?(:tags) 
+    return nil unless resource.has_taxonomy?(:tags)
     @displayable_tags ||= resource.taxonomy[:tags].reject { |_pro_path, tag| tag.start_with?('culturelover') }
   end
 
   def theme_label_tags
-    return nil unless resource.has_taxonomy?(:tags) 
+    return nil unless resource.has_taxonomy?(:tags)
     @theme_label_tags ||= resource.taxonomy[:tags].select { |_pro_path, tag| tag.start_with?('culturelover-') }
   end
 

--- a/app/presenters/pro_resource_presenter.rb
+++ b/app/presenters/pro_resource_presenter.rb
@@ -37,9 +37,15 @@ class ProResourcePresenter
     displayable_tags.present?
   end
 
-  # We omit from view the "culturelover" internal-use tag
+  # We omit from view internal-use tags starting "culturelover"
   def displayable_tags
-    resource.taxonomy[:tags].reject { |_pro_path, tag| tag == 'culturelover' }
+    return nil unless resource.has_taxonomy?(:tags) 
+    @displayable_tags ||= resource.taxonomy[:tags].reject { |_pro_path, tag| tag.start_with?('culturelover') }
+  end
+
+  def theme_label_tags
+    return nil unless resource.has_taxonomy?(:tags) 
+    @theme_label_tags ||= resource.taxonomy[:tags].select { |_pro_path, tag| tag.start_with?('culturelover-') }
   end
 
   def tags
@@ -81,11 +87,12 @@ class ProResourcePresenter
     resource.persons.flatten.compact
   end
 
-  # @todo this likely needs to be more generic, or moved into a blog presenter
-  #   subclass
   def label
-    return nil unless resource.has_taxonomy?(:blogs)
-    resource.taxonomy[:blogs].values.first
+    return nil unless theme_label_tags.present?
+    topics = theme_label_tags.map do |_pro_path, tag|
+      Topic.find_by_slug(tag.split('-').last)
+    end.compact
+    topics.blank? ? nil : topics.map(&:label).join(' | ')
   end
 
   def geolocation

--- a/app/views/blog_posts/index.rb
+++ b/app/views/blog_posts/index.rb
@@ -4,6 +4,14 @@ module BlogPosts
     include PaginatedJsonApiResultSetView
     include ThemeFilterableView
 
+    def theme_filters
+      pro_json_api_theme_filters
+    end
+
+    def selected_theme
+      pro_json_api_selected_theme
+    end
+
     def page_title
       mustache[:page_title] ||= begin
         [t('site.blogs.list.page-title'), site_title].join(' - ')

--- a/app/views/blog_posts/index.rb
+++ b/app/views/blog_posts/index.rb
@@ -2,6 +2,7 @@
 module BlogPosts
   class Index < ApplicationView
     include PaginatedJsonApiResultSetView
+    include ThemeFilterableView
 
     def page_title
       mustache[:page_title] ||= begin
@@ -31,20 +32,10 @@ module BlogPosts
 
     def blogs_filter_options
       return nil unless config.x.enable.blog_posts_theme_filter
-      {
-        filter_name: 'theme',
-        options: filter_options
-      }
+      theme_filter_options
     end
 
     protected
-
-    def filter_options
-      @theme_filters.map { |key, data| { label: data[:label], value: key } }.tap do |options|
-        selected_option = options.delete(options.detect { |option| option[:value] == @selected_theme })
-        options.unshift(selected_option) unless selected_option.nil?
-      end
-    end
 
     def blog_item(post)
       presenter = ProResourcePresenter.new(self, post)

--- a/app/views/concerns/theme_filterable_view.rb
+++ b/app/views/concerns/theme_filterable_view.rb
@@ -6,8 +6,8 @@ module ThemeFilterableView
   protected
 
   def theme_filter_options
-    options = @theme_filters.map { |key, data| { label: data[:label], value: key } }.tap do |options|
-      selected_option = options.delete(options.detect { |option| option[:value] == @selected_theme })
+    options = theme_filters.map { |key, data| { label: data[:label], value: key } }.tap do |options|
+      selected_option = options.delete(options.detect { |option| option[:value] == selected_theme })
       options.unshift(selected_option) unless selected_option.nil?
     end
 

--- a/app/views/concerns/theme_filterable_view.rb
+++ b/app/views/concerns/theme_filterable_view.rb
@@ -9,7 +9,7 @@ module ThemeFilterableView
   def theme_filter_options
     theme_options = theme_filters.map { |key, data| { label: data[:label], value: key } }.tap do |options|
       selected_option = options.delete(options.detect { |option| option[:value] == selected_theme })
-      options.unshift(selected_option) unless selected_option.nil?
+      options.unshift(selected_option.merge(selected: true)) unless selected_option.nil?
     end
 
     {

--- a/app/views/concerns/theme_filterable_view.rb
+++ b/app/views/concerns/theme_filterable_view.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ##
 # Filtering by theme
 module ThemeFilterableView
@@ -6,14 +7,14 @@ module ThemeFilterableView
   protected
 
   def theme_filter_options
-    options = theme_filters.map { |key, data| { label: data[:label], value: key } }.tap do |options|
+    theme_options = theme_filters.map { |key, data| { label: data[:label], value: key } }.tap do |options|
       selected_option = options.delete(options.detect { |option| option[:value] == selected_theme })
       options.unshift(selected_option) unless selected_option.nil?
     end
 
     {
       filter_name: 'theme',
-      options: options
+      options: theme_options
     }
   end
 end

--- a/app/views/concerns/theme_filterable_view.rb
+++ b/app/views/concerns/theme_filterable_view.rb
@@ -1,0 +1,19 @@
+##
+# Filtering by theme
+module ThemeFilterableView
+  extend ActiveSupport::Concern
+
+  protected
+
+  def theme_filter_options
+    options = @theme_filters.map { |key, data| { label: data[:label], value: key } }.tap do |options|
+      selected_option = options.delete(options.detect { |option| option[:value] == @selected_theme })
+      options.unshift(selected_option) unless selected_option.nil?
+    end
+
+    {
+      filter_name: 'theme',
+      options: options
+    }
+  end
+end

--- a/app/views/events/index.rb
+++ b/app/views/events/index.rb
@@ -48,7 +48,7 @@ module Events
     def events_order_options
       order_options = order_filters.map { |key, data| { label: data[:label], value: key } }.tap do |options|
         selected_option = options.delete(options.detect { |option| option[:value] == selected_order })
-        options.unshift(selected_option) unless selected_option.nil?
+        options.unshift(selected_option.merge(selected: true)) unless selected_option.nil?
       end
 
       {

--- a/app/views/events/index.rb
+++ b/app/views/events/index.rb
@@ -2,6 +2,7 @@
 module Events
   class Index < ApplicationView
     include PaginatedJsonApiResultSetView
+    include ThemeFilterableView
 
     def page_title
       mustache[:page_title] ||= begin
@@ -27,6 +28,11 @@ module Events
 
     def event_items
       @events.map { |event| event_item(event) }
+    end
+
+    def events_filter_options
+      return nil unless config.x.enable.events_theme_filter
+      theme_filter_options
     end
 
     protected

--- a/app/views/events/index.rb
+++ b/app/views/events/index.rb
@@ -46,14 +46,14 @@ module Events
     # @todo this selected filter option logic should be abstracted into a concern
     #   or helper method to DRY things up. See also `ThemeFilterableView#theme_filter_options`
     def events_order_options
-      options = order_filters.map { |key, data| { label: data[:label], value: key } }.tap do |options|
+      order_options = order_filters.map { |key, data| { label: data[:label], value: key } }.tap do |options|
         selected_option = options.delete(options.detect { |option| option[:value] == selected_order })
         options.unshift(selected_option) unless selected_option.nil?
       end
 
       {
         filter_name: 'order',
-        options: options
+        options: order_options
       }
     end
 

--- a/app/views/events/index.rb
+++ b/app/views/events/index.rb
@@ -4,6 +4,14 @@ module Events
     include PaginatedJsonApiResultSetView
     include ThemeFilterableView
 
+    def theme_filters
+      pro_json_api_theme_filters
+    end
+
+    def selected_theme
+      pro_json_api_selected_theme
+    end
+
     def page_title
       mustache[:page_title] ||= begin
         [t('site.events.list.page-title'), site_title].join(' - ')
@@ -33,6 +41,20 @@ module Events
     def events_filter_options
       return nil unless config.x.enable.events_theme_filter
       theme_filter_options
+    end
+
+    # @todo this selected filter option logic should be abstracted into a concern
+    #   or helper method to DRY things up. See also `ThemeFilterableView#theme_filter_options`
+    def events_order_options
+      options = order_filters.map { |key, data| { label: data[:label], value: key } }.tap do |options|
+        selected_option = options.delete(options.detect { |option| option[:value] == selected_order })
+        options.unshift(selected_option) unless selected_option.nil?
+      end
+
+      {
+        filter_name: 'order',
+        options: options
+      }
     end
 
     protected

--- a/app/views/events/index.rb
+++ b/app/views/events/index.rb
@@ -46,14 +46,14 @@ module Events
     # @todo this selected filter option logic should be abstracted into a concern
     #   or helper method to DRY things up. See also `ThemeFilterableView#theme_filter_options`
     def events_order_options
-      order_options = order_filters.map { |key, data| { label: data[:label], value: key } }.tap do |options|
-        selected_option = options.delete(options.detect { |option| option[:value] == selected_order })
+      selected_past_future_options = past_future_filters.map { |key, data| { label: data[:label], value: key } }.tap do |options|
+        selected_option = options.delete(options.detect { |option| option[:value] == selected_past_future })
         options.unshift(selected_option.merge(selected: true)) unless selected_option.nil?
       end
 
       {
-        filter_name: 'order',
-        options: order_options
+        filter_name: 'sort',
+        options: selected_past_future_options
       }
     end
 

--- a/app/views/events/index.rb
+++ b/app/views/events/index.rb
@@ -40,7 +40,7 @@ module Events
         date: presenter.date_range(:start_event, :end_event),
         location: presenter.location_name,
         img: presenter.image(:thumbnail, :teaser_image),
-        label: nil,
+        label: presenter.label,
         tags: presenter.tags
       }
     end

--- a/app/views/events/show.rb
+++ b/app/views/events/show.rb
@@ -19,7 +19,7 @@ module Events
           tags: presenter.tags,
           label: presenter.label,
           event_date: presenter.date_range(:start_event, :end_event),
-          date: presenter.date_range(:start_event, :end_event),
+          date: presenter.date,
           introduction: presenter.introduction,
           event_image: presenter.image(:url, :teaser_image),
           geolocation: presenter.geolocation,

--- a/app/views/events/show.rb
+++ b/app/views/events/show.rb
@@ -19,7 +19,7 @@ module Events
           tags: presenter.tags,
           label: presenter.label,
           event_date: presenter.date_range(:start_event, :end_event),
-          date: presenter.date,
+          date: presenter.date_range(:start_event, :end_event),
           introduction: presenter.introduction,
           event_image: presenter.image(:url, :teaser_image),
           geolocation: presenter.geolocation,

--- a/config/initializers/env.rb
+++ b/config/initializers/env.rb
@@ -30,5 +30,6 @@ end
 # Enable certain features that are disabled by default
 Rails.application.config.x.enable = OpenStruct.new(
   blog_posts_theme_filter: ENV['ENABLE_BLOG_POSTS_THEME_FILTER'],
+  events_theme_filter: ENV['ENABLE_EVENTS_THEME_FILTER'],
   search_form_autocomplete: ENV['ENABLE_SEARCH_FORM_AUTOCOMPLETE']
 )

--- a/spec/controllers/blog_posts_controller_spec.rb
+++ b/spec/controllers/blog_posts_controller_spec.rb
@@ -24,10 +24,18 @@ RSpec.describe BlogPostsController do
   end
 
   describe 'GET #index' do
-    it 'queries the Pro JSON-API for 6 posts' do
+    it 'queries the Pro JSON-API' do
       get :index, locale: 'en'
       expect(
         a_request(:get, json_api_url)
+      ).to have_been_made.once
+    end
+
+    it 'filters by tag "culturelover"' do
+      get :index, locale: 'en'
+      expect(
+        a_request(:get, json_api_url).
+        with(query: hash_including(filter: { tags: 'culturelover' }))
       ).to have_been_made.once
     end
 
@@ -82,7 +90,7 @@ RSpec.describe BlogPostsController do
       get :show, locale: 'en', slug: 'important-news'
       expect(
         a_request(:get, json_api_url).
-        with(query: hash_including(filter: { blogs: 'europeana-fashion', slug: 'important-news' }, page: { number: '1', size: '1' }))
+        with(query: hash_including(filter: { tags: 'culturelover', slug: 'important-news' }, page: { number: '1', size: '1' }))
       ).to have_been_made.once
     end
 

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -30,6 +30,14 @@ RSpec.describe EventsController do
       ).to have_been_made.once
     end
 
+    it 'filters by date and tag "culturelover"' do
+      get :index, locale: 'en'
+      expect(
+        a_request(:get, json_api_url).
+        with(query: hash_including(filter: { end_event: ">=#{Date.today.strftime}", tags: 'culturelover' }))
+      ).to have_been_made.once
+    end
+
     it 'requests 6 event posts' do
       get :index, locale: 'en'
       expect(
@@ -81,7 +89,7 @@ RSpec.describe EventsController do
       get :show, locale: 'en', slug: 'conference'
       expect(
         a_request(:get, json_api_url).
-        with(query: hash_including(filter: { slug: 'conference' }, page: { number: '1', size: '1' }))
+        with(query: hash_including(filter: { tags: 'culturelover', slug: 'conference' }, page: { number: '1', size: '1' }))
       ).to have_been_made.once
     end
 

--- a/spec/fixtures/api_response/pro_blog_posts.json.erb
+++ b/spec/fixtures/api_response/pro_blog_posts.json.erb
@@ -22,8 +22,8 @@
                 },
                 "taxonomy": {
                     "tags": {
-                        "\/tags\/first": "first",
-                        "\/tags\/second": "second"
+                        "\/tags\/culturelover": "culturelover",
+                        "\/tags\/culturelover-fashion": "culturelover-fashion"
                     },
                     "blogs": {
                         "\/blogs\/europeana-blog": "Europeana Blog"

--- a/spec/presenters/pro_resource_presenter_spec.rb
+++ b/spec/presenters/pro_resource_presenter_spec.rb
@@ -22,9 +22,9 @@ RSpec.describe ProResourcePresenter do
   end
 
   describe '#label' do
-    it 'uses the first value of blogs taxonomy' do
-      allow(resource).to receive(:taxonomy) { { blogs: { '/path' => 'interesting blog' } } }
-      expect(subject.label).to eq('interesting blog')
+    it 'uses culturelover-theme tags to look up topics' do
+      allow(resource).to receive(:taxonomy) { { tags: { '/path' => 'culturelover-fashion' } } }
+      expect(subject.label).to eq('Fashion')
     end
   end
 

--- a/spec/views/blog_posts/index_spec.rb
+++ b/spec/views/blog_posts/index_spec.rb
@@ -13,16 +13,17 @@ RSpec.describe 'blog_posts/index.html.mustache' do
   end
   let(:theme_filters) do
     {
-      all: { filter: 'all-blog-posts', label: 'All' },
-      fashion: { filter: 'fashion-blog-posts', label: 'Fashion' },
+      all: { filter: 'culturelover', label: 'All' },
+      fashion: { filter: 'culturelover-fashion', label: 'Fashion' },
     }
   end
 
   before do
     allow(view).to receive(:pagination_page) { pagination_page }
     allow(view).to receive(:pagination_per) { pagination_per }
+    allow(view).to receive(:pro_json_api_theme_filters) { theme_filters }
+    allow(view).to receive(:pro_json_api_selected_theme) { :all }
     assign(:blog_posts, blog_posts)
-    assign(:theme_filters, theme_filters)
   end
 
   it_behaves_like 'paginated_view'
@@ -37,9 +38,9 @@ RSpec.describe 'blog_posts/index.html.mustache' do
     expect(rendered).to have_selector('h2 a', text: blog_posts.first.title)
   end
 
-  it 'uses blogs taxonomy for category flag' do
+  it 'uses culturelover-theme tag for category flag' do
     render
-    expect(rendered).to have_selector('.item-preview .category-flag', text: blog_posts.first.taxonomy[:blogs].values.first)
+    expect(rendered).to have_selector('.item-preview .category-flag', text: 'Fashion')
   end
 
   context 'with theme filter enabled' do


### PR DESCRIPTION
* Events and blog posts from Pro JSON API are now always filtered by tag: "culturelover" for all, "culturelover-fashion" for Fashion
* Labels on tiles on listing pages are taken from any "culturelover-theme" tags, with a lookup for a label in the `Topic` model, where "theme" from the tag needs to match a topic slug
* Events can be filtered by theme, but this is not exposed unless `ENABLE_EVENTS_THEME_FILTER` is set
* Events default to future events only, but can be switched to show past, although the front-end does not respect the field name defined for this