### PR TITLE
No CSRF meta tags

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,9 @@
 ## Enable blog posts theme filter [EXPERIMENTAL]
 # ENABLE_BLOG_POSTS_THEME_FILTER=1
 
+## Enable requests to /csrf without SSL
+# ENABLE_CSRF_WITHOUT_SSL=1
+
 ## Enable events theme filter [EXPERIMENTAL]
 # ENABLE_EVENTS_THEME_FILTER=1
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'rails', '4.2.7.1'
 
 # NB: this *must* be by Git ref; else will break asset versioning in
 #     config/initializers/assets.rb, preventing app startup
-gem 'europeana-styleguide', github: 'europeana/europeana-styleguide-ruby', ref: '5e6e367'
+gem 'europeana-styleguide', github: 'europeana/europeana-styleguide-ruby', ref: '70aa665'
 
 # Lock Mustache at 1.0.3 because > 1.0.3 kills item page performance with the commit
 # https://github.com/mustache/mustache/commit/3c7af8f33d0c3b04c159e10e73a2831cf1e56e02

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,8 +24,8 @@ GIT
 
 GIT
   remote: git://github.com/europeana/europeana-styleguide-ruby.git
-  revision: 5e6e367d6f10a33efae8a037a60d0a2585cfba44
-  ref: 5e6e367
+  revision: 70aa66521d64da7179de7761f50408ad81ac36a2
+  ref: 70aa665
   specs:
     europeana-styleguide (0.2.0)
       activesupport (~> 4.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,6 +16,17 @@ class ApplicationController < ActionController::Base
 
   layout proc { kind_of?(Europeana::Styleguide) ? false : 'application' }
 
+  def csrf
+    respond_to do |format|
+      format.json do
+        render json: {
+          param: request_forgery_protection_token,
+          token: form_authenticity_token
+        }
+      end
+    end
+  end
+
   def current_user
     super || User.new(guest: true)
   end

--- a/app/controllers/galleries_controller.rb
+++ b/app/controllers/galleries_controller.rb
@@ -27,16 +27,9 @@ class GalleriesController < ApplicationController
   def show
     @gallery = Gallery.find_by_slug(params[:slug])
     authorize! :show, @gallery
-    images = @gallery.images
 
     @body_cache_key = 'explore/' + @gallery.cache_key
-
-    if body_cached?
-      @hero_image_url = gallery_hero_image_from_cache
-    else
-      @documents = search_api_for_image_metadata(images)
-      set_gallery_hero_image_cache(images.first)
-    end
+    @documents = search_api_for_image_metadata(@gallery.images) unless body_cached?
 
     respond_to do |format|
       format.html
@@ -58,16 +51,6 @@ class GalleriesController < ApplicationController
   def search_api_for_image_metadata(images)
     return [] if images.blank?
     search_results(blacklight_api_params_for_images(images)).last
-  end
-
-  def gallery_hero_image_from_cache
-    Rails.cache.fetch(cache_key(@body_cache_key) + '/hero_image_url')
-  end
-
-  def set_gallery_hero_image_cache(image)
-    image_document = @documents.detect { |document| document.fetch(:id, nil) == image.europeana_record_id }
-    @hero_image_url = image_document['edmIsShownBy'].first
-    Rails.cache.write(cache_key(@body_cache_key) + '/hero_image_url', @hero_image_url, expires_in: 24.hours + 1.minute)
   end
 
   def blacklight_api_params_for_images(images)

--- a/app/views/application_view.rb
+++ b/app/views/application_view.rb
@@ -24,17 +24,19 @@ class ApplicationView < Europeana::Styleguide::View
 
   def js_vars
     [
-      { name: 'googleAnalyticsKey', value: config.x.google[:analytics_key] }
+      { name: 'googleAnalyticsKey', value: config.x.google[:analytics_key] },
+      { name: 'enableCSRFWithoutSSL', value: config.x.enable[:csrf_without_ssl] }
     ] + super
   end
 
   def head_meta
-    return super unless config.x.google.key?(:site_verification)
+    no_csrf = super.reject { |meta| %w(csrf-param csrf-token).include?(meta[:meta_name]) }
+    return no_csrf unless config.x.google.key?(:site_verification)
     [
       {
         meta_name: 'google-site-verification', content: config.x.google[:site_verification]
       }
-    ] + super
+    ] + no_csrf
   end
 
   def head_links

--- a/app/views/blog_posts/show.html.mustache
+++ b/app/views/blog_posts/show.html.mustache
@@ -1,5 +1,5 @@
-{{>atoms/meta/_head}}
 {{#cached_body}}
-  {{>templates/Search/Search-blog-item}}
+  {{>atoms/meta/_head}}
+    {{>templates/Search/Search-blog-item}}
+  {{>atoms/meta/_foot}}
 {{/cached_body}}
-{{>atoms/meta/_foot}}

--- a/app/views/blog_posts/show.rb
+++ b/app/views/blog_posts/show.rb
@@ -2,7 +2,7 @@
 module BlogPosts
   class Show < ApplicationView
     def blog_title
-      body_cached? ? title_from_cached_body : presenter.title
+      presenter.title
     end
     alias_method :page_content_heading, :blog_title
 

--- a/app/views/collections/show.html.mustache
+++ b/app/views/collections/show.html.mustache
@@ -1,10 +1,10 @@
-{{>atoms/meta/_head}}
 {{#cached_body}}
+  {{>atoms/meta/_head}}
   {{#content.layout_default}}
     {{>templates/Search/Channels-landing}}
   {{/content.layout_default}}
   {{#content.layout_browse}}
       {{>templates/Search/Channels-landing-browse}}
   {{/content.layout_browse}}
+  {{>atoms/meta/_foot}}
 {{/cached_body}}
-{{>atoms/meta/_foot}}

--- a/app/views/concerns/cacheable_view.rb
+++ b/app/views/concerns/cacheable_view.rb
@@ -14,15 +14,6 @@ module CacheableView
     end
   end
 
-  def cached_body_content
-    Rails.cache.fetch(cache_key(body_cache_key))
-  end
-
-  def title_from_cached_body
-    title = cached_body_content.match(%r{<div class="title text-centre">(.*?)</div>})[1]
-    CGI.unescapeHTML(title)
-  end
-
   # Override this method in view classes to enable body caching
   def body_cache_key
     fail NotImplementedError

--- a/app/views/events/show.html.mustache
+++ b/app/views/events/show.html.mustache
@@ -1,5 +1,6 @@
-{{>atoms/meta/_head}}
 {{#cached_body}}
+  {{>atoms/meta/_head}}
   {{>templates/Search/Search-event-item}}
+  {{>atoms/meta/_foot}}
 {{/cached_body}}
-{{>atoms/meta/_foot}}
+

--- a/app/views/events/show.rb
+++ b/app/views/events/show.rb
@@ -2,7 +2,7 @@
 module Events
   class Show < ApplicationView
     def event_title
-      body_cached? ? title_from_cached_body : presenter.title
+      presenter.title
     end
     alias_method :page_content_heading, :event_title
 

--- a/app/views/explore/colours.html.mustache
+++ b/app/views/explore/colours.html.mustache
@@ -1,5 +1,5 @@
-{{>atoms/meta/_head}}
 {{#cached_body}}
+  {{>atoms/meta/_head}}
   {{> templates/Search/Search-colours}}
+  {{>atoms/meta/_foot}}
 {{/cached_body}}
-{{>atoms/meta/_foot}}

--- a/app/views/explore/new_content.html.mustache
+++ b/app/views/explore/new_content.html.mustache
@@ -1,7 +1,7 @@
-{{>atoms/meta/_head}}
-
 {{#cached_body}}
+  {{>atoms/meta/_head}}
   {{>templates/Search/Search-new-content }}
+  {{>atoms/meta/_foot}}
 {{/cached_body}}
 
-{{>atoms/meta/_foot}}
+

--- a/app/views/explore/people.html.mustache
+++ b/app/views/explore/people.html.mustache
@@ -1,5 +1,6 @@
-{{>atoms/meta/_head}}
 {{#cached_body}}
+  {{>atoms/meta/_head}}
   {{> templates/Search/Search-browse-entries}}
+  {{>atoms/meta/_foot}}
 {{/cached_body}}
-{{>atoms/meta/_foot}}
+

--- a/app/views/explore/periods.html.mustache
+++ b/app/views/explore/periods.html.mustache
@@ -1,5 +1,6 @@
-{{>atoms/meta/_head}}
 {{#cached_body}}
+  {{>atoms/meta/_head}}
   {{> templates/Search/Search-browse-entries}}
+  {{>atoms/meta/_foot}}
 {{/cached_body}}
-{{>atoms/meta/_foot}}
+

--- a/app/views/explore/sources.html.mustache
+++ b/app/views/explore/sources.html.mustache
@@ -1,5 +1,5 @@
-{{>atoms/meta/_head}}
 {{#cached_body}}
+  {{>atoms/meta/_head}}
   {{> templates/Search/Search-sources}}
+  {{>atoms/meta/_foot}}
 {{/cached_body}}
-{{>atoms/meta/_foot}}

--- a/app/views/explore/topics.html.mustache
+++ b/app/views/explore/topics.html.mustache
@@ -1,5 +1,5 @@
-{{>atoms/meta/_head}}
 {{#cached_body}}
+  {{>atoms/meta/_head}}
   {{> templates/Search/Search-browse-entries}}
+  {{>atoms/meta/_foot}}
 {{/cached_body}}
-{{>atoms/meta/_foot}}

--- a/app/views/galleries/index.html.mustache
+++ b/app/views/galleries/index.html.mustache
@@ -1,5 +1,6 @@
-{{>atoms/meta/_head}}
 {{#cached_body}}
+  {{>atoms/meta/_head}}
   {{>templates/Search/Gallery-foyer}}
+  {{>atoms/meta/_foot}}
 {{/cached_body}}
-{{>atoms/meta/_foot}}
+

--- a/app/views/galleries/show.html.mustache
+++ b/app/views/galleries/show.html.mustache
@@ -1,5 +1,5 @@
-{{>atoms/meta/_head}}
 {{#cached_body}}
-  {{>templates/Search/Gallery-page}}
+  {{>atoms/meta/_head}}
+    {{>templates/Search/Gallery-page}}
+  {{>atoms/meta/_foot}}
 {{/cached_body}}
-{{>atoms/meta/_foot}}

--- a/app/views/galleries/show.rb
+++ b/app/views/galleries/show.rb
@@ -7,8 +7,8 @@ module Galleries
       'channel_landing'
     end
 
-    def page_title
-      mustache[:page_title] ||= [@gallery.title, site_title].join(' - ')
+    def page_content_heading
+      @gallery.title
     end
 
     def head_links
@@ -24,7 +24,7 @@ module Galleries
         head_meta = gallery_head_meta + [
           { meta_name: 'description', content: description },
           { meta_property: 'og:description', content: description },
-          { meta_property: 'og:image', content: @hero_image_url },
+          { meta_property: 'og:image', content: hero_image_url },
           { meta_property: 'og:title', content: @gallery.title },
           { meta_property: 'og:sitename', content: @gallery.title }
         ]
@@ -49,9 +49,17 @@ module Galleries
 
     private
 
+    def hero_image_url
+      @hero_image_url ||= hero_image_document['edmIsShownBy'].first
+    end
+
+    def hero_image_document
+      @hero_image_document ||= @documents.detect { |document| document.fetch(:id, nil) == @gallery.images.first.europeana_record_id }
+    end
+
     def gallery_hero_content
       {
-        url: @hero_image_url,
+        url: hero_image_url,
         title: @gallery.title,
         subtitle: @gallery.description
       }

--- a/app/views/home/index.html.mustache
+++ b/app/views/home/index.html.mustache
@@ -1,5 +1,6 @@
-{{>atoms/meta/_head}}
 {{#cached_body}}
+  {{>atoms/meta/_head}}
   {{>templates/Search/Search-home}}
+  {{>atoms/meta/_foot}}
 {{/cached_body}}
-{{>atoms/meta/_foot}}
+

--- a/app/views/pages/show.html.mustache
+++ b/app/views/pages/show.html.mustache
@@ -1,5 +1,6 @@
-{{>atoms/meta/_head}}
 {{#cached_body}}
+  {{>atoms/meta/_head}}
   {{>templates/Search/Search-static-page}}
+  {{>atoms/meta/_foot}}
 {{/cached_body}}
-{{>atoms/meta/_foot}}
+

--- a/config/initializers/env.rb
+++ b/config/initializers/env.rb
@@ -30,6 +30,7 @@ end
 # Enable certain features that are disabled by default
 Rails.application.config.x.enable = OpenStruct.new(
   blog_posts_theme_filter: ENV['ENABLE_BLOG_POSTS_THEME_FILTER'],
+  csrf_without_ssl: ENV['ENABLE_CSRF_WITHOUT_SSL'],
   events_theme_filter: ENV['ENABLE_EVENTS_THEME_FILTER'],
   search_form_autocomplete: ENV['ENABLE_SEARCH_FORM_AUTOCOMPLETE']
 )

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,6 +68,8 @@ Rails.application.routes.draw do
     mount Europeana::FeedbackButton::Engine, at: '/'
   end
 
+  get 'csrf', to: 'application#csrf'
+
   put 'locale', to: 'locale#update'
   get '*path', to: 'locale#show'
 end

--- a/spec/controllers/galleries_controller_spec.rb
+++ b/spec/controllers/galleries_controller_spec.rb
@@ -152,17 +152,6 @@ RSpec.describe GalleriesController do
         expect(assigns[:gallery]).to eq(gallery)
       end
 
-      it 'assigns the edmIsShownBy of the first image to @hero_image_url' do
-        get :show, locale: 'en', slug: gallery.slug
-        expect(assigns[:hero_image_url]).to eq('providerurl/sample/record1')
-      end
-
-      it 'caches the hero_image_url' do
-        expect(Rails.cache).to_not receive(:fetch)
-        expect(Rails.cache).to receive(:write).with(an_instance_of(String), an_instance_of(String), expires_in: 24.hours + 1.minute)
-        get :show, locale: 'en', slug: gallery.slug
-      end
-
       it 'searches the API for the gallery image metadata' do
         get :show, locale: 'en', slug: gallery.slug
         ids = gallery.images.map(&:europeana_record_id)
@@ -177,16 +166,9 @@ RSpec.describe GalleriesController do
           allow(subject).to receive(:body_cached?) { true }
         end
 
-        it 'does NOT searche the API for the gallery image metadata' do
+        it 'does NOT search the API for the gallery image metadata' do
           get :show, locale: 'en', slug: gallery.slug
           expect(an_api_search_request).to_not have_been_made
-        end
-
-        it 'assigns a url from the cache to @hero_image_url' do
-          expect(Rails.cache).to_not receive(:write)
-          expect(Rails.cache).to receive(:fetch) { 'something' }
-          get :show, locale: 'en', slug: gallery.slug
-          expect(assigns[:hero_image_url]).to eq('something')
         end
       end
     end


### PR DESCRIPTION
Re https://app.assembla.com/spaces/europeana-npc/tickets/1997-omit-csrf-meta-tags-from-html-head/details

CSRF tokens can instead be requested in advance of affected AJAX requests by sending a pre-flight GET request to /portal/csrf.json

Blog posts, events and galleries now have their full HTML cached, avoiding the need for various workarounds to repopulate elements in the HTML head when the body was cached and API calls not made to supply the data.