### PR TITLE
use FacetLinkGroupPresenter for preview search label

### DIFF
--- a/app/views/collections/show.rb
+++ b/app/views/collections/show.rb
@@ -126,10 +126,10 @@ module Collections
 
     def carousel_data
       case @landing_page.settings[:layout_type]
-        when 'default'
-          helpers.tumblr_feed_content(@landing_page)
-        when 'browse'
-          helpers.page_feeds_content(@landing_page)
+      when 'default'
+        helpers.tumblr_feed_content(@landing_page)
+      when 'browse'
+        helpers.page_feeds_content(@landing_page)
       end
     end
 
@@ -172,30 +172,26 @@ module Collections
 
     # @todo refactor to:
     # - make modular have this be a concern
-    # - lookup proper search title & type using labeling from  presenters/concerns/facet/labelling.rb
-    # - refactor facet_entry_field_title to not be called for each facet entry
     def preview_search_data
       return nil if @landing_page.facet_entries.blank?
 
       @landing_page.facet_entries.map do |facet_entry|
+        presenter = facet_entry_presenter(facet_entry)
         {
-          preview_search_title: facet_entry_display_value(facet_entry),
-          preview_search_type: facet_entry_field_title(facet_entry),
+          preview_search_title: presenter.facet_item_label(facet_entry.facet_value) || facet_entry.title,
+          preview_search_type: presenter.facet_title || facet_entry.facet_field,
           preview_search_url: browse_entry_url(facet_entry, @landing_page, format: 'json'),
           preview_search_more_link: browse_entry_url(facet_entry, @landing_page)
         }
       end
     end
 
-    def facet_entry_field_title(facet_entry)
-      ff = Europeana::Blacklight::Response::Facets::FacetField.new(facet_entry.facet_field, [])
-      presenter = FacetPresenter.build(ff, controller)
-      presenter.facet_title || facet_entry.facet_field
-    end
-
-    def facet_entry_display_value(facet_entry)
-      presenter = FacetLinkGroupPresenter.new(facet_entry.facet_link_group, controller, blacklight_config)
-      presenter.facet_entry_item(facet_entry)[:label] || facet_entry.title
+    def facet_entry_presenter(facet_entry)
+      @facet_presenters ||= {}
+      @facet_presenters[facet_entry.facet_field] ||= begin
+        ff = Europeana::Blacklight::Response::Facets::FacetField.new(facet_entry.facet_field, [])
+        FacetPresenter.build(ff, controller)
+      end
     end
   end
 end

--- a/app/views/collections/show.rb
+++ b/app/views/collections/show.rb
@@ -179,7 +179,7 @@ module Collections
 
       @landing_page.facet_entries.map do |facet_entry|
         {
-          preview_search_title: facet_entry.title,
+          preview_search_title: facet_entry_display_value(facet_entry),
           preview_search_type: facet_entry_field_title(facet_entry),
           preview_search_url: browse_entry_url(facet_entry, @landing_page, format: 'json'),
           preview_search_more_link: browse_entry_url(facet_entry, @landing_page)
@@ -191,6 +191,11 @@ module Collections
       ff = Europeana::Blacklight::Response::Facets::FacetField.new(facet_entry.facet_field, [])
       presenter = FacetPresenter.build(ff, controller)
       presenter.facet_title || facet_entry.facet_field
+    end
+
+    def facet_entry_display_value(facet_entry)
+      presenter = FacetLinkGroupPresenter.new(facet_entry.facet_link_group, controller, blacklight_config)
+      presenter.facet_entry_item(facet_entry)[:label] || facet_entry.title
     end
   end
 end


### PR DESCRIPTION
The changes made are using FacetLinkGroupPresenter instead of calling the FacetPresenter directly since the FacetPresenter needs a Europeana::Blacklight::Response::Facets::FacetItem and the Europeana::Blacklight::Response::Facets::FacetField the FacetLinkGroupPresenter works with the FacetEntry directly so it keeps the facet_entry_display_value method cleaner.
