### PR TITLE
re: #2184 hero license links added to concern

### DIFF
--- a/app/models/hero_image.rb
+++ b/app/models/hero_image.rb
@@ -22,7 +22,7 @@ class HeroImage < ActiveRecord::Base
 
   class << self
     def license_enum
-      %w(CC0 CC_BY CC_BY_SA CC_BY_ND CC_BY_NC CC_BY_NC_SA CC_BY_NC_ND OOC PD_NC public RR_free RR_paid RR_restricted unknown orphan)
+      %w(public CC0 CC_BY CC_BY_SA CC_BY_ND CC_BY_NC CC_BY_NC_SA CC_BY_NC_ND RS_INC_EDU RS_NOC_OKLR RS_INC RS_NOC_NC RS_INC_OW_EU RS_CNE)
     end
 
     def settings_brand_opacity_enum

--- a/app/views/concerns/hero_image_displaying_view.rb
+++ b/app/views/concerns/hero_image_displaying_view.rb
@@ -3,6 +3,23 @@
 module HeroImageDisplayingView
   extend ActiveSupport::Concern
 
+  LICENSES_URL = {
+    'public' => 'https://creativecommons.org/publicdomain/mark/1.0/',
+    'CC0' => 'https://creativecommons.org/publicdomain/zero/1.0/',
+    'CC_BY' => 'https://creativecommons.org/licenses/by/1.0',
+    'CC_BY_SA' => 'https://creativecommons.org/licenses/by-sa/1.0',
+    'CC_BY_ND' => 'https://creativecommons.org/licenses/by-nc-nd/1.0',
+    'CC_BY_NC' => 'https://creativecommons.org/licenses/by-nc/1.0',
+    'CC_BY_NC_SA' => 'https://creativecommons.org/licenses/by-nc-sa/1.0',
+    'CC_BY_NC_ND' => 'https://creativecommons.org/licenses/by-nc-nd/1.0',
+    'RS_INC_EDU' => 'http://rightsstatements.org/vocab/InC-EDU/1.0/',
+    'RS_NOC_OKLR' => 'http://rightsstatements.org/vocab/NoC-OKLR/1.0/',
+    'RS_INC' => 'http://rightsstatements.org/vocab/InC/1.0/',
+    'RS_NOC_NC' => 'http://rightsstatements.org/vocab/NoC-NC/1.0/',
+    'RS_INC_OW_EU' => 'http://rightsstatements.org/vocab/InC-OW-EU/1.0/',
+    'RS_CNE' => 'http://rightsstatements.org/vocab/CNE/1.0/'
+  }
+
   protected
 
   def hero_config(hero_image)
@@ -25,7 +42,14 @@ module HeroImageDisplayingView
   end
 
   def hero_license(hero_image)
-    hero_image.license.blank? ? {} : { hero_license_template_var_name(hero_image.license) => true }
+    if hero_image.license.blank?
+      {}
+    else
+      {
+        hero_license_template_var_name(hero_image.license) => true,
+        license_url: LICENSES_URL[hero_image.license]
+      }
+    end
   end
 
   def hero_license_template_var_name(license)

--- a/spec/models/hero_image_spec.rb
+++ b/spec/models/hero_image_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe HeroImage do
 
   describe '.license_enum' do
     subject { described_class.license_enum }
-    it { is_expected.to eq(%w(CC0 CC_BY CC_BY_SA CC_BY_ND CC_BY_NC CC_BY_NC_SA CC_BY_NC_ND OOC PD_NC public RR_free RR_paid RR_restricted unknown orphan)) }
+    it { is_expected.to eq(%w(public CC0 CC_BY CC_BY_SA CC_BY_ND CC_BY_NC CC_BY_NC_SA CC_BY_NC_ND RS_INC_EDU RS_NOC_OKLR RS_INC RS_NOC_NC RS_INC_OW_EU RS_CNE)) }
   end
 
   describe '.settings_brand_opacity_enum' do


### PR DESCRIPTION
The main problem here was that we never had the URLs anywhere and weren't setting license_url for the template.
This PR updates the licenses we use to conform with the list as per https://europeanadev.assembla.com/spaces/europeana-npc/tickets/2184