### PR TITLE
Hero licenses from edm rights

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'rails', '4.2.7.1'
 # NB: this *must* be by Git ref; else will break asset versioning in
 #     config/initializers/assets.rb, preventing app startup
 
-gem 'europeana-styleguide', github: 'europeana/europeana-styleguide-ruby', ref: '935a950'
+gem 'europeana-styleguide', github: 'europeana/europeana-styleguide-ruby', ref: 'bd0bffe'
 
 # Lock Mustache at 1.0.3 because > 1.0.3 kills item page performance with the commit
 # https://github.com/mustache/mustache/commit/3c7af8f33d0c3b04c159e10e73a2831cf1e56e02

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,8 +13,8 @@ GIT
 
 GIT
   remote: git://github.com/europeana/europeana-styleguide-ruby.git
-  revision: 935a9503cc3f8acc1266f6a6b57e57d063fc6ce2
-  ref: 935a950
+  revision: bd0bffedbb8e09ce4f9bb2d3fa9365f20b3a0af6
+  ref: bd0bffe
   specs:
     europeana-styleguide (0.2.0)
       activesupport (~> 4.0)

--- a/app/models/hero_image.rb
+++ b/app/models/hero_image.rb
@@ -22,7 +22,7 @@ class HeroImage < ActiveRecord::Base
 
   class << self
     def license_enum
-      %w(CC0 CC_BY CC_BY_SA CC_BY_ND CC_BY_NC CC_BY_NC_SA CC_BY_NC_ND OOC PD_NC public RR_free RR_paid RR_restricted unknown orphan)
+      %w(public CC0 CC_BY CC_BY_SA CC_BY_ND CC_BY_NC CC_BY_NC_SA CC_BY_NC_ND RS_INC_EDU RS_NOC_OKLR RS_INC RS_NOC_NC RS_INC_OW_EU RS_CNE)
     end
 
     def settings_brand_opacity_enum

--- a/app/views/concerns/hero_image_displaying_view.rb
+++ b/app/views/concerns/hero_image_displaying_view.rb
@@ -3,6 +3,23 @@
 module HeroImageDisplayingView
   extend ActiveSupport::Concern
 
+  LICENSES_URL = {
+    'public' => 'https://creativecommons.org/publicdomain/mark/1.0/',
+    'CC0' => 'https://creativecommons.org/publicdomain/zero/1.0/',
+    'CC_BY' => 'https://creativecommons.org/licenses/by/1.0',
+    'CC_BY_SA' => 'https://creativecommons.org/licenses/by-sa/1.0',
+    'CC_BY_ND' => 'https://creativecommons.org/licenses/by-nc-nd/1.0',
+    'CC_BY_NC' => 'https://creativecommons.org/licenses/by-nc/1.0',
+    'CC_BY_NC_SA' => 'https://creativecommons.org/licenses/by-nc-sa/1.0',
+    'CC_BY_NC_ND' => 'https://creativecommons.org/licenses/by-nc-nd/1.0',
+    'RS_INC_EDU' => 'http://rightsstatements.org/vocab/InC-EDU/1.0/',
+    'RS_NOC_OKLR' => 'http://rightsstatements.org/vocab/NoC-OKLR/1.0/',
+    'RS_INC' => 'http://rightsstatements.org/vocab/InC/1.0/',
+    'RS_NOC_NC' => 'http://rightsstatements.org/vocab/NoC-NC/1.0/',
+    'RS_INC_OW_EU' => 'http://rightsstatements.org/vocab/InC-OW-EU/1.0/',
+    'RS_CNE' => 'http://rightsstatements.org/vocab/CNE/1.0/'
+  }
+
   protected
 
   def hero_config(hero_image)
@@ -25,7 +42,14 @@ module HeroImageDisplayingView
   end
 
   def hero_license(hero_image)
-    hero_image.license.blank? ? {} : { hero_license_template_var_name(hero_image.license) => true }
+    if hero_image.license.blank?
+      {}
+    else
+      {
+        hero_license_template_var_name(hero_image.license) => true,
+        license_url: LICENSES_URL[hero_image.license]
+      }
+    end
   end
 
   def hero_license_template_var_name(license)

--- a/app/views/concerns/hero_image_displaying_view.rb
+++ b/app/views/concerns/hero_image_displaying_view.rb
@@ -3,23 +3,6 @@
 module HeroImageDisplayingView
   extend ActiveSupport::Concern
 
-  LICENSES_URL = {
-    'public' => 'https://creativecommons.org/publicdomain/mark/1.0/',
-    'CC0' => 'https://creativecommons.org/publicdomain/zero/1.0/',
-    'CC_BY' => 'https://creativecommons.org/licenses/by/1.0',
-    'CC_BY_SA' => 'https://creativecommons.org/licenses/by-sa/1.0',
-    'CC_BY_ND' => 'https://creativecommons.org/licenses/by-nc-nd/1.0',
-    'CC_BY_NC' => 'https://creativecommons.org/licenses/by-nc/1.0',
-    'CC_BY_NC_SA' => 'https://creativecommons.org/licenses/by-nc-sa/1.0',
-    'CC_BY_NC_ND' => 'https://creativecommons.org/licenses/by-nc-nd/1.0',
-    'RS_INC_EDU' => 'http://rightsstatements.org/vocab/InC-EDU/1.0/',
-    'RS_NOC_OKLR' => 'http://rightsstatements.org/vocab/NoC-OKLR/1.0/',
-    'RS_INC' => 'http://rightsstatements.org/vocab/InC/1.0/',
-    'RS_NOC_NC' => 'http://rightsstatements.org/vocab/NoC-NC/1.0/',
-    'RS_INC_OW_EU' => 'http://rightsstatements.org/vocab/InC-OW-EU/1.0/',
-    'RS_CNE' => 'http://rightsstatements.org/vocab/CNE/1.0/'
-  }
-
   protected
 
   def hero_config(hero_image)
@@ -47,7 +30,7 @@ module HeroImageDisplayingView
     else
       {
         hero_license_template_var_name(hero_image.license) => true,
-        license_url: LICENSES_URL[hero_image.license]
+        license_url: hero_image.license_url
       }
     end
   end

--- a/config/edm/rights.yml
+++ b/config/edm/rights.yml
@@ -1,34 +1,44 @@
 ---
 # Free re-use / REUSABILITY="open"
 open:
+  public:
+    pattern: "https?://creativecommons.org/publicdomain/mark"
+    url: "https://creativecommons.org/publicdomain/mark/1.0/"
   cc0:
     pattern: "https?://creativecommons.org/(licenses/)?publicdomain/zero"
+    url: "https://creativecommons.org/publicdomain/zero/1.0/"
   cc_by:
     pattern: "https?://creativecommons.org/licenses/by/"
+    url: "https://creativecommons.org/licenses/by/1.0"
   cc_by_sa:
     pattern: "https?://creativecommons.org/licenses/by-sa"
-  pdm:
-    pattern: "https?://creativecommons.org/publicdomain/mark"
-    template_license: public
+    url: "https://creativecommons.org/licenses/by-sa/1.0"
 # Limited re-use / REUSABILITY="restricted"
 restricted:
   cc_by_nc:
     pattern: "https?://creativecommons.org/licenses/by-nc/"
+    url: "https://creativecommons.org/licenses/by-nc/1.0"
   cc_by_nc_nd:
     pattern: "https?://creativecommons.org/licenses/by-nc-nd"
+    url: "https://creativecommons.org/licenses/by-nc-nd/1.0"
   cc_by_nc_sa:
     pattern: "https?://creativecommons.org/licenses/by-nc-sa"
+    url: "https://creativecommons.org/licenses/by-nc-sa/1.0"
   cc_by_nd:
     pattern: "https?://creativecommons.org/licenses/by-nd"
+    url: "http://creativecommons.org/licenses/by-nd/4.0/'"
   out_of_copyright_non_commercial:
     pattern: "https?://www.europeana.eu/rights/out-of-copyright-non-commercial"
     template_license: OOC
   rs_inc_edu:
     pattern: "https?://rightsstatements.org/vocab/InC-EDU/*"
+    url: "http://rightsstatements.org/vocab/InC-EDU/1.0/"
   rs_noc_nc:
     pattern: "https?://rightsstatements.org/vocab/NoC-NC/*"
+    url: "http://rightsstatements.org/vocab/NoC-NC/1.0/"
   rs_noc_oklr:
     pattern: "https?://rightsstatements.org/vocab/NoC-OKLR/*"
+    url: "http://rightsstatements.org/vocab/NoC-OKLR/1.0/"
 # No re-use / REUSABILITY="permission"
 permission:
   rrfa:
@@ -48,7 +58,10 @@ permission:
     template_license: orphan
   rs_inc:
     pattern: "https?://rightsstatements.org/vocab/InC/*"
+    url: "http://rightsstatements.org/vocab/InC/1.0/"
   rs_inc_ow_eu:
     pattern: "https?://rightsstatements.org/vocab/InC-OW-EU/*"
+    url: "http://rightsstatements.org/vocab/InC-OW-EU/1.0/"
   rs_cne:
     pattern: "https?://rightsstatements.org/vocab/CNE/*"
+    url: "http://rightsstatements.org/vocab/CNE/1.0/"

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -243,7 +243,6 @@ RailsAdmin.config do |config|
       field :file, :paperclip do
         thumb_method :medium
       end
-      field :license
       group :brand do
         field :settings_brand_opacity, :enum do
           enum do
@@ -264,7 +263,13 @@ RailsAdmin.config do |config|
     end
     edit do
       field :file, :paperclip
-      field :license
+      field :license, :enum do
+        enum do
+          HeroImage.license_enum.map do |hero_license|
+            [HeroImage.edm_rights(hero_license).label, hero_license]
+          end
+        end
+      end
       group :brand do
         field :settings_brand_opacity, :enum do
           enum do

--- a/spec/models/hero_image_spec.rb
+++ b/spec/models/hero_image_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe HeroImage do
   end
 
   describe '.license_enum' do
-    subject { described_class.license_enum }
-    it { is_expected.to eq(%w(public CC0 CC_BY CC_BY_SA CC_BY_ND CC_BY_NC CC_BY_NC_SA CC_BY_NC_ND RS_INC_EDU RS_NOC_OKLR RS_INC RS_NOC_NC RS_INC_OW_EU RS_CNE)) }
+    subject { described_class.license_enum.sort }
+    it { is_expected.to eq(%w(public CC0 CC_BY CC_BY_SA CC_BY_ND CC_BY_NC CC_BY_NC_SA CC_BY_NC_ND RS_INC_EDU RS_NOC_OKLR RS_INC RS_NOC_NC RS_INC_OW_EU RS_CNE).sort) }
   end
 
   describe '.settings_brand_opacity_enum' do
@@ -64,6 +64,13 @@ RSpec.describe HeroImage do
           end
         end
       end
+    end
+  end
+
+  describe '#license_url' do
+    it 'is looked up from EDM::Rights' do
+      hero = described_class.new(license: 'public')
+      expect(hero.license_url).to eq('https://creativecommons.org/publicdomain/mark/1.0/')
     end
   end
 end

--- a/spec/models/hero_image_spec.rb
+++ b/spec/models/hero_image_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe HeroImage do
 
   describe '.license_enum' do
     subject { described_class.license_enum }
-    it { is_expected.to eq(%w(CC0 CC_BY CC_BY_SA CC_BY_ND CC_BY_NC CC_BY_NC_SA CC_BY_NC_ND OOC PD_NC public RR_free RR_paid RR_restricted unknown orphan)) }
+    it { is_expected.to eq(%w(public CC0 CC_BY CC_BY_SA CC_BY_ND CC_BY_NC CC_BY_NC_SA CC_BY_NC_ND RS_INC_EDU RS_NOC_OKLR RS_INC RS_NOC_NC RS_INC_OW_EU RS_CNE)) }
   end
 
   describe '.settings_brand_opacity_enum' do


### PR DESCRIPTION
Re: https://app.assembla.com/spaces/europeana-npc/tickets/2184, and refactoring https://github.com/europeana/europeana-portal-collections/pull/901

* Gemfile updates the styleguide to a hotfixed version of it for a localisation update: https://github.com/europeana/europeana-styleguide-ruby/commit/bd0bffedbb8e09ce4f9bb2d3fa9365f20b3a0af6 (renaming Public Domain license i18n key from "pdm" to "public")
* URLs to link to from hero images are added to the config/edm/rights.yml
* All rights in that YAML file having a url like that are considered eligible for hero image licenses, and hero image license enum is populated on that basis
* In the CMS, rights labels are now displayed instead of keys