### PR TITLE
Migration AddDefaultToBanners fails

### DIFF
--- a/db/migrate/20160119093141_add_default_to_banners.rb
+++ b/db/migrate/20160119093141_add_default_to_banners.rb
@@ -5,6 +5,7 @@ class AddDefaultToBanners < ActiveRecord::Migration
     add_column :banners, :default, :boolean, default: false
     add_index :banners, :default
 
-    Banner.find_by_key('phase-feedback').update_attributes(default: true)
+    banner = Banner.find_by_key('phase-feedback')
+    banner.update_attributes(default: true) if banner
   end
 end

--- a/db/migrate/20160119093141_add_default_to_banners.rb
+++ b/db/migrate/20160119093141_add_default_to_banners.rb
@@ -5,7 +5,6 @@ class AddDefaultToBanners < ActiveRecord::Migration
     add_column :banners, :default, :boolean, default: false
     add_index :banners, :default
 
-    banner = Banner.find_by_key('phase-feedback')
-    banner.update_attributes(default: true) if banner
+    Banner.find_by_key('phase-feedback')&.update_attributes(default: true)
   end
 end


### PR DESCRIPTION
When I run `rake db:migrate` all goes well until I hit the `AddDefaultToBanners` migration when the following error is generated:
```
undefined method `update_attributes' for nil:NilClass
```
This problem is fixed when I check if `Banner.find_by_key('phase-feedback')` returns a valid banner object.