### PR TITLE
use zero promo tile for og:image on browse landing pages

### DIFF
--- a/app/models/page/landing.rb
+++ b/app/models/page/landing.rb
@@ -43,7 +43,7 @@ class Page
     end
 
     def og_image
-      og_image_from_promo || og_image_from_hero
+      @og_image ||= og_image_from_promo || og_image_from_hero
     end
 
     private

--- a/app/models/page/landing.rb
+++ b/app/models/page/landing.rb
@@ -42,7 +42,21 @@ class Page
       settings[:layout_type] ? settings[:layout_type] : 'default'
     end
 
+    def og_image
+      og_image_from_promo || og_image_from_hero
+    end
+
     private
+
+    def og_image_from_promo
+      return unless settings_layout_type == 'browse'
+      promo = promotions.find_by(position: 0)
+      promo && promo.file.present? ? promo.file.url : nil
+    end
+
+    def og_image_from_hero
+      hero_image && hero_image.file.present? ? hero_image.file.url : nil
+    end
 
     def set_slug
       new_slug = collection.key == 'all' ? '' : "collections/#{collection.key}"

--- a/app/views/collections/show.rb
+++ b/app/views/collections/show.rb
@@ -25,7 +25,7 @@ module Collections
           { meta_property: 'og:url', content: collection_url(@collection.key) }
         ]
         head_meta << { meta_property: 'og:title', content: title } unless title.nil?
-        head_meta << { meta_property: 'og:image', content: og_image } unless og_image.blank?
+        head_meta << { meta_property: 'og:image', content: @landing_page.og_image } unless @landing_page.og_image.blank?
         head_meta + super
       end
     end
@@ -102,21 +102,6 @@ module Collections
     end
 
     private
-
-    def og_image
-      og_image_from_promo || og_image_from_hero
-    end
-
-    def og_image_from_promo
-      return unless @landing_page.settings_layout_type == 'browse'
-      promo = @landing_page.promotions.find_by(position: 0)
-      promo && promo.file.present? ? promo.file.url : nil
-    end
-
-    def og_image_from_hero
-      hero_conf = hero_config(@landing_page.hero_image)
-      hero_conf[:hero_image] unless hero_conf.nil? || hero_conf[:hero_image].blank?
-    end
 
     def head_meta_description
       mustache[:head_meta_description] ||= begin

--- a/app/views/collections/show.rb
+++ b/app/views/collections/show.rb
@@ -115,7 +115,7 @@ module Collections
 
     def og_image_from_hero
       hero_conf = hero_config(@landing_page.hero_image)
-      URI.join(root_url, hero_conf[:hero_image]) unless hero_conf.nil? || hero_conf[:hero_image].blank?
+      hero_conf[:hero_image] unless hero_conf.nil? || hero_conf[:hero_image].blank?
     end
 
     def head_meta_description

--- a/app/views/collections/show.rb
+++ b/app/views/collections/show.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Collections
   class Show < ApplicationView
     include BrowsableView
@@ -13,7 +15,6 @@ module Collections
     def head_meta
       mustache[:head_meta] ||= begin
         title = page_title
-        hero = hero_config(@landing_page.hero_image)
         head_meta = [
           { meta_name: 'description', content: head_meta_description },
           { meta_property: 'fb:appid', content: '185778248173748' },
@@ -24,7 +25,7 @@ module Collections
           { meta_property: 'og:url', content: collection_url(@collection.key) }
         ]
         head_meta << { meta_property: 'og:title', content: title } unless title.nil?
-        head_meta << { meta_property: 'og:image', content: URI.join(root_url, hero[:hero_image]) } unless hero.nil?
+        head_meta << { meta_property: 'og:image', content: og_image } unless og_image.blank?
         head_meta + super
       end
     end
@@ -101,6 +102,21 @@ module Collections
     end
 
     private
+
+    def og_image
+      og_image_from_promo || og_image_from_hero
+    end
+
+    def og_image_from_promo
+      return unless @landing_page.settings_layout_type == 'browse'
+      promo = @landing_page.promotions.find_by(position: 0)
+      promo && promo.file.present? ? promo.file.url : nil
+    end
+
+    def og_image_from_hero
+      hero_conf = hero_config(@landing_page.hero_image)
+      URI.join(root_url, hero_conf[:hero_image]) unless hero_conf.nil? || hero_conf[:hero_image].blank?
+    end
 
     def head_meta_description
       mustache[:head_meta_description] ||= begin

--- a/app/views/galleries/index.rb
+++ b/app/views/galleries/index.rb
@@ -23,7 +23,7 @@ module Galleries
         gallery_head_meta + [
           { meta_name: 'description', content: t('site.galleries.description') },
           { meta_property: 'og:description', content: t('site.galleries.description') },
-          { meta_property: 'og:image', content: @hero_image.file.present? ? URI.join(root_url, @hero_image.file.url) : nil },
+          { meta_property: 'og:image', content: @hero_image.file.present? ? @hero_image.file.url : nil },
           { meta_property: 'og:title', content: page_title },
           { meta_property: 'og:sitename', content: page_title }
         ] + super

--- a/app/views/home/index.rb
+++ b/app/views/home/index.rb
@@ -51,7 +51,7 @@ module Home
           { meta_property: 'og:url', content: root_url }
         ]
         head_meta << { meta_property: 'og:title', content: title } unless title.nil?
-        head_meta << { meta_property: 'og:image', content: URI.join(root_url, hero[:hero_image]) } unless hero.nil?
+        head_meta << { meta_property: 'og:image', content: hero[:hero_image] } unless hero.nil?
         head_meta + super
       end
     end

--- a/spec/fixtures/links.yml
+++ b/spec/fixtures/links.yml
@@ -1,3 +1,10 @@
 default_banner_link:
   url: 'http://www.example.com/'
   linkable: default_banner (Banner)
+
+fashion_promo_link:
+  url: 'http://europeanafashion.tumblr.com/'
+  linkable: fashion_collection (Page)
+  type: 'Link::Promotion'
+  position: 0
+  media_object: fake_file

--- a/spec/fixtures/media_objects.yml
+++ b/spec/fixtures/media_objects.yml
@@ -1,0 +1,5 @@
+fake_file:
+  file_file_name: 'fake-file.jpg'
+  file_content_type: 'image/jpeg'
+  file_file_size: 452799
+  file_fingerprint: 'ea6a8d814b7d3df608d3f83f8423096c'

--- a/spec/fixtures/pages.yml
+++ b/spec/fixtures/pages.yml
@@ -41,6 +41,7 @@ fashion_collection:
   state: 1
   type: 'Page::Landing'
   newsletter_url: 'http://europeanafashion.us5.list-manage.com/subscribe?u=08acbb4918e78ab1b8b1cb158&id=eeaec60e70'
+  settings: "--- !ruby/hash:ActiveSupport::HashWithIndifferentAccess\nlayout_type: browse\n"
   feeds:
     - fashion_blog
     - fashion_tumblr

--- a/spec/models/page/landing_spec.rb
+++ b/spec/models/page/landing_spec.rb
@@ -64,4 +64,30 @@ RSpec.describe Page::Landing do
       end
     end
   end
+
+  describe '#og_image' do
+    it 'should return an image from either the first promo tile or the hero image' do
+      expect(subject).to receive(:og_image_from_promo) { false }
+      expect(subject).to receive(:og_image_from_hero) { 'the hero image' }
+      expect(subject.og_image).to eq('the hero image')
+    end
+  end
+
+  describe '#og_image_from_promo' do
+    context 'when the page uses the default layout' do
+      let(:page) { pages(:music_collection) }
+
+      it 'should always be nil' do
+        expect(page.send(:og_image_from_promo)).to be_nil
+      end
+    end
+
+    context 'when the page uses the browse layout' do
+      let(:page) { pages(:fashion_collection) }
+
+      it 'should return the image from the promo tile with position 0' do
+        expect(page.send(:og_image_from_promo)).to eq(media_objects(:fake_file).file.url)
+      end
+    end
+  end
 end

--- a/spec/views/collections/show_spec.rb
+++ b/spec/views/collections/show_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe 'collections/show.html.mustache', :common_view_components, :blacklight_config, :stable_version_view do
   include ActionView::Helpers::TextHelper
 
@@ -5,7 +7,7 @@ RSpec.describe 'collections/show.html.mustache', :common_view_components, :black
     Rails.cache.write('record/counts/collections/music/type/image', 10)
     assign(:collection, collection)
     assign(:landing_page, landing_page)
-    assign(:params, { id: collection.id })
+    assign(:params, id: collection.id)
     allow(controller).to receive(:blacklight_config).and_return(blacklight_config)
     allow(view).to receive(:blacklight_config).and_return(blacklight_config)
     allow(view).to receive(:has_search_parameters?).and_return(false)
@@ -35,5 +37,15 @@ RSpec.describe 'collections/show.html.mustache', :common_view_components, :black
     expect(subject).to have_link('All')
     expect(subject).to have_link('Images')
     expect(subject).not_to have_link('3D')
+  end
+
+  context 'when the page is using the browse layout' do
+    let(:collection) { Collection.find_by_key('fashion') }
+    let(:landing_page) { Page::Landing.find_by_slug('collections/fashion') }
+
+    it 'should set the og image to the image of the promo with a position of Zero' do
+      expected_og_url = landing_page.promotions.find_by(position: 0).file.url
+      expect(subject).to have_selector("meta[property=\"og:image\"][content=\"#{expected_og_url}\"]", visible: false)
+    end
   end
 end


### PR DESCRIPTION
For browse landing pages use the image from the promo tile at position 0, if this isn't found for any reason or the landing page is using the default display, default to the hero image.
+specs