### PR TITLE
Feat/2303 blog caches

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -114,9 +114,6 @@
 ## Time each day at which to run the exhibitions feed caching job. No default.
 # SCHEDULE_FEED_EXHIBITIONS="04:00"
 
-## Time each day at which to run the feed caching jobs. No default.
-# SCHEDULE_FEED_CUSTOM="04:30"
-
 ## Time each day at which to run the record count caching job. No default.
 # SCHEDULE_RECORD_COUNTS="05:00"
 

--- a/app/jobs/cache/expiry/page_job.rb
+++ b/app/jobs/cache/expiry/page_job.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Cache
+  module Expiry
+    ##
+    # Job to expire the cached version of a page
+    class PageJob < ApplicationJob
+      include CacheHelper
+
+      queue_as :cache
+
+      def perform(page_id = nil)
+        expire_cache(Page.find(page_id).cache_key)
+      end
+    end
+  end
+end

--- a/app/jobs/cache/expiry/page_job.rb
+++ b/app/jobs/cache/expiry/page_job.rb
@@ -9,7 +9,7 @@ module Cache
 
       queue_as :cache
 
-      def perform(page_id = nil)
+      def perform(page_id)
         expire_cache(Page.find(page_id).cache_key)
       end
     end

--- a/app/jobs/cache/feed_job.rb
+++ b/app/jobs/cache/feed_job.rb
@@ -11,33 +11,37 @@ module Cache
     queue_as :cache
 
     def perform(url, download_media = false)
-      feed = begin
+      @url = url
+      @download_media = download_media
+
+      @feed = begin
         benchmark("[Feedjira] #{url}", level: :info) do
-          Feedjira::Feed.fetch_and_parse(url)
+          Feedjira::Feed.fetch_and_parse(@url)
         end
       end
 
-      feed_cache_key = Feed.find_by_url(url).cache_key
+      feed_cache_key = Feed.find_by_url(@url).cache_key
       cached_feed = Rails.cache.fetch(feed_cache_key)
-      if cached_feed.blank? || cached_feed.last_modified != feed.last_modified
-        Rails.cache.write(feed_cache_key, feed)
-        updated = true
+
+      if cached_feed.blank? || cached_feed.last_modified != @feed.last_modified
+        Rails.cache.write(feed_cache_key, @feed)
+        @updated = true
       end
-      after_perform(feed, url, download_media) if updated
     end
 
     # Global nav uses some feeds, and is cached so needs to be expired when those
     # feeds are updated.
     # Cached pages need to be expired should they be using the updated feed.
-    def after_perform(feed, url, download_media)
-      if download_media
-        feed.entries.each do |entry|
+    after_perform do
+      return unless @updated
+      if @download_media
+        @feed.entries.each do |entry|
           img_url = FeedEntryImage.new(entry).media_object_url
           DownloadRemoteMediaObjectJob.perform_later(img_url) unless img_url.nil?
         end
       end
-      Cache::Expiry::GlobalNavJob.perform_later if NavigableView.feeds_included_in_nav_urls.include?(url)
-      Page.joins(:feeds).where('feeds.url' => url).references(:feeds).each do |page|
+      Cache::Expiry::GlobalNavJob.perform_later if NavigableView.feeds_included_in_nav_urls.include?(@url)
+      Page.joins(:feeds).where('feeds.url' => @url).references(:feeds).each do |page|
         Cache::Expiry::PageJob.perform_later(page.id)
       end
     end

--- a/app/jobs/cache/feed_job.rb
+++ b/app/jobs/cache/feed_job.rb
@@ -11,9 +11,7 @@ module Cache
     queue_as :cache
 
     def perform(url, download_media = false)
-      @url = url
-
-      @feed = begin
+      feed = begin
         benchmark("[Feedjira] #{url}", level: :info) do
           Feedjira::Feed.fetch_and_parse(url)
         end
@@ -21,28 +19,26 @@ module Cache
 
       feed_cache_key = Feed.find_by_url(url).cache_key
       cached_feed = Rails.cache.fetch(feed_cache_key)
-      if cached_feed.blank? || cached_feed.last_modified != @feed.last_modified
-        Rails.cache.write(feed_cache_key, @feed)
-        @updated = true
+      if cached_feed.blank? || cached_feed.last_modified != feed.last_modified
+        Rails.cache.write(feed_cache_key, feed)
+        updated = true
       end
+      after_perform(feed, url, download_media) if updated
+    end
 
+    # Global nav uses some feeds, and is cached so needs to be expired when those
+    # feeds are updated.
+    # Cached pages need to be expired should they be using the updated feed.
+    def after_perform(feed, url, download_media)
       if download_media
-        @feed.entries.each do |entry|
+        feed.entries.each do |entry|
           img_url = FeedEntryImage.new(entry).media_object_url
           DownloadRemoteMediaObjectJob.perform_later(img_url) unless img_url.nil?
         end
       end
-    end
-  end
-
-  # Global nav uses some feeds, and is cached so needs to be expired when those
-  # feeds are updated.
-  # Cached pages need to be expired should they be using the updated feed.
-  def after_perform
-    if @updated
-      Cache::Expire::GlobalNavJob.perform_later if NavigableView.feeds_included_in_nav_urls.include?(@url)
-      Page.joins(:feeds).where('feed.url' => @url).each do |page|
-        Cache::Expire::PageJob.perform_later(page.id)
+      Cache::Expiry::GlobalNavJob.perform_later if NavigableView.feeds_included_in_nav_urls.include?(url)
+      Page.joins(:feeds).where('feeds.url' => url).references(:feeds).each do |page|
+        Cache::Expiry::PageJob.perform_later(page.id)
       end
     end
   end

--- a/app/jobs/cache/feed_job.rb
+++ b/app/jobs/cache/feed_job.rb
@@ -46,6 +46,4 @@ module Cache
       end
     end
   end
-
-
 end

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -25,6 +25,10 @@ class Feed < ActiveRecord::Base
     slug
   end
 
+  def requeue
+    queue_retrieval
+  end
+
   private
 
   def queue_retrieval

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -29,6 +29,10 @@ class Feed < ActiveRecord::Base
     queue_retrieval
   end
 
+  def cache_key
+    "feed/#{url}"
+  end
+
   private
 
   def queue_retrieval

--- a/app/views/blog_posts/index.rss.builder
+++ b/app/views/blog_posts/index.rss.builder
@@ -6,7 +6,7 @@ xml.rss(version: '2.0', 'xmlns:atom' => 'http://www.w3.org/2005/Atom') do
     xml.description(t('site.blogs.description'))
     xml.link(blog_posts_url)
     xml.language(locale.to_s)
-    xml.lastBuildDate(Date.parse(@blog_posts.first.datepublish).rfc2822)
+    xml.lastBuildDate(DateTime.parse(@blog_posts.first.datepublish).rfc2822)
     xml.tag!('atom:link', rel: 'self', type: 'application/rss+xml', href: blog_posts_url(format: 'rss'))
 
     @blog_posts.each do |blog_post|
@@ -22,7 +22,7 @@ xml.rss(version: '2.0', 'xmlns:atom' => 'http://www.w3.org/2005/Atom') do
           xml.enclosure(url: thumb[:url], length: 0, type: 'image/*')
         end
         xml.guid(blog_post_url(blog_post.slug))
-        xml.pubDate(Date.parse(blog_post.datepublish).rfc2822)
+        xml.pubDate(DateTime.parse(blog_post.datepublish).rfc2822)
       end
     end
   end

--- a/app/views/events/index.rss.builder
+++ b/app/views/events/index.rss.builder
@@ -6,7 +6,7 @@ xml.rss(version: '2.0', 'xmlns:atom' => 'http://www.w3.org/2005/Atom', 'xmlns:ev
     xml.description(t('site.events.description'))
     xml.link(events_url)
     xml.language(locale.to_s)
-    xml.lastBuildDate(Date.parse(@events.first.datepublish).rfc2822)
+    xml.lastBuildDate(DateTime.parse(@events.first.datepublish).rfc2822)
     xml.tag!('atom:link', rel: 'self', type: 'application/rss+xml', href: events_url(format: 'rss'))
 
     @events.each do |event|
@@ -21,9 +21,9 @@ xml.rss(version: '2.0', 'xmlns:atom' => 'http://www.w3.org/2005/Atom', 'xmlns:ev
           xml.enclosure(url: thumb[:url], length: 0, type: 'image/*')
         end
         xml.guid(event_url(event.slug))
-        xml.pubDate(Date.parse(event.datepublish).rfc2822)
-        xml.ev(:startdate, Date.parse(event.start_event).iso8601)
-        xml.ev(:enddate, Date.parse(event.end_event).iso8601)
+        xml.pubDate(DateTime.parse(event.datepublish).rfc2822)
+        xml.ev(:startdate, DateTime.parse(event.start_event).iso8601)
+        xml.ev(:enddate, DateTime.parse(event.end_event).iso8601)
         xml.ev(:location, event.locations.first.title)
       end
     end

--- a/app/views/rails_admin/main/requeue.html.haml
+++ b/app/views/rails_admin/main/requeue.html.haml
@@ -1,0 +1,15 @@
+%h4
+  = t("admin.form.are_you_sure_you_want_to_requeue_the_object", model_name: @abstract_model.pretty_name.downcase)
+  &ldquo;
+  %strong>= @model_config.with(object: @object).object_label
+  \&rdquo;
+  %span>
+= form_for(@object, url: requeue_path(model_name: @abstract_model.to_param, id: @object.id), html: {method: "put"}) do
+  %input{type: :hidden, name: 'return_to', value: (params[:return_to].presence || request.referer)}
+  .form-actions
+    %button.btn.btn-primary{type: "submit", :'data-disable-with' => t("admin.form.confirmation")}
+      %i.icon-white.icon-ok
+      = t("admin.form.confirmation")
+    %button.btn{type: "submit", name: "_continue", :'data-disable-with' => t("admin.form.cancel")}
+      %i.icon-remove
+      = t("admin.form.cancel")

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require 'rails_admin/config/actions/publish'
 require 'rails_admin/config/actions/unpublish'
+require 'rails_admin/config/actions/requeue'
 require 'rails_admin/config/fields/extensions/generic_help'
 
 RailsAdmin::Config::Fields::Types::Text.send(:include, RailsAdmin::Config::Fields::Extensions::GenericHelp)
@@ -40,6 +41,7 @@ RailsAdmin.config do |config|
     history_show
     publish
     unpublish
+    requeue
   end
 
   config.model 'Banner' do

--- a/config/locales/rails_admin.en.yml
+++ b/config/locales/rails_admin.en.yml
@@ -13,8 +13,15 @@ en:
         link: "Unpublish '%{object_label}'"
         menu: "Unpublish"
         title: "Unpublish %{model_label} '%{object_label}'"
+      requeue:
+        breadcrumb: "Requeue"
+        done: "requeued"
+        link: "Requeue '%{object_label}'"
+        menu: "Requeue"
+        title: "Requeue %{model_label} '%{object_label}'"
     form:
       are_you_sure_you_want_to_publish_the_object: "Are you sure you want to publish this %{model_name}?"
+      are_you_sure_you_want_to_requeue_the_object: "Are you sure you want to requeue this %{model_name}?"
       are_you_sure_you_want_to_unpublish_the_object: "Are you sure you want to unpublish this %{model_name}?"
     help:
       browse_entry:

--- a/lib/clock.rb
+++ b/lib/clock.rb
@@ -11,7 +11,7 @@ unless ENV['DISABLE_SCHEDULED_JOBS']
     end
   end
 
-  every(1.day, 'cache.feed.custom', at: ENV['SCHEDULE_FEED_CUSTOM']) do
+  every(1.hour, 'cache.feed.custom') do
     Feed.all.each do |feed|
       Cache::FeedJob.perform_later(feed.url, true)
     end

--- a/lib/rails_admin/config/actions/publish.rb
+++ b/lib/rails_admin/config/actions/publish.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/actions'
 require 'rails_admin/config/actions/base'
 
@@ -29,7 +31,7 @@ module RailsAdmin
         end
 
         register_instance_option :http_methods do
-          [:get, :put]
+          %i(get put)
         end
 
         register_instance_option :authorization_key do

--- a/lib/rails_admin/config/actions/requeue.rb
+++ b/lib/rails_admin/config/actions/requeue.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/actions'
 require 'rails_admin/config/actions/base'
 module RailsAdmin
@@ -15,7 +17,7 @@ module RailsAdmin
         end
 
         register_instance_option :http_methods do
-          [:get, :put]
+          %i(get put)
         end
 
         register_instance_option :authorization_key do

--- a/lib/rails_admin/config/actions/requeue.rb
+++ b/lib/rails_admin/config/actions/requeue.rb
@@ -1,0 +1,58 @@
+require 'rails_admin/config/actions'
+require 'rails_admin/config/actions/base'
+module RailsAdmin
+  module Config
+    module Actions
+      class Requeue < Base
+        RailsAdmin::Config::Actions.register(self)
+
+        register_instance_option :member do
+          true
+        end
+
+        register_instance_option :route_fragment do
+          'requeue'
+        end
+
+        register_instance_option :http_methods do
+          [:get, :put]
+        end
+
+        register_instance_option :authorization_key do
+          :requeue
+        end
+
+        register_instance_option :link_icon do
+          'icon-refresh'
+        end
+
+        register_instance_option :visible? do
+          authorized? && bindings[:object].respond_to?(:requeue)
+        end
+
+        register_instance_option :bulkable? do
+          true
+        end
+
+        register_instance_option :controller do
+          proc do
+            if request.get? # ASK FOR CONFIRMATION
+              respond_to do |format|
+                format.html { render @action.template_name }
+              end
+            elsif request.put? # REQUEUE
+              if @object.requeue
+                respond_to do |format|
+                  format.html { redirect_to_on_success }
+                  format.js { render json: { id: @object.id.to_s, label: @model_config.with(object: @object).object_label } }
+                end
+              else
+                handle_save_error :requeue
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rails_admin/config/actions/unpublish.rb
+++ b/lib/rails_admin/config/actions/unpublish.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/actions'
 require 'rails_admin/config/actions/base'
 
@@ -29,7 +31,7 @@ module RailsAdmin
         end
 
         register_instance_option :http_methods do
-          [:get, :put]
+          %i(get put)
         end
 
         register_instance_option :authorization_key do

--- a/spec/jobs/cache/expire/page_job_spec.rb
+++ b/spec/jobs/cache/expire/page_job_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Cache::Expiry::PageJob do
     end
 
     it 'expires the cache entry' do
-      expect { subject.perform(page) }.to change { Rails.cache.fetch(page_cache_key) }.from(page_cache_content).to(nil)
+      expect { subject.perform(page.id) }.to change { Rails.cache.fetch(page_cache_key) }.from(page_cache_content).to(nil)
     end
   end
 end

--- a/spec/jobs/cache/expire/page_job_spec.rb
+++ b/spec/jobs/cache/expire/page_job_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Cache::Expiry::PageJob do
   include CacheHelper
 
-  let(:page) {pages(:music_collection)}
+  let(:page) { pages(:music_collection) }
   context 'when the page is cached' do
     let(:page_cache_key) do
       cache_key(page.cache_key, locale: 'en', user_role: 'guest')

--- a/spec/jobs/cache/expire/page_job_spec.rb
+++ b/spec/jobs/cache/expire/page_job_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+RSpec.describe Cache::Expiry::PageJob do
+  include CacheHelper
+
+  let(:page) {pages(:music_collection)}
+  context 'when the page is cached' do
+    let(:page_cache_key) do
+      cache_key(page.cache_key, locale: 'en', user_role: 'guest')
+    end
+    let(:page_cache_content) { 'cached page' }
+
+    before do
+      Rails.cache.write(page_cache_key, page_cache_content)
+    end
+
+    it 'expires the cache entry' do
+      expect { subject.perform(page) }.to change { Rails.cache.fetch(page_cache_key) }.from(page_cache_content).to(nil)
+    end
+  end
+end

--- a/spec/jobs/cache/feed_job_spec.rb
+++ b/spec/jobs/cache/feed_job_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Cache::FeedJob do
   before(:each) do
     stub_request(:get, url).
@@ -32,8 +34,6 @@ RSpec.describe Cache::FeedJob do
     subject.perform(url)
     expect(a_request(:get, url)).to have_been_made.at_least_once
   end
-
-
 
   it 'should cache the feed' do
     cache_key = "feed/#{url}"

--- a/spec/jobs/cache/feed_job_spec.rb
+++ b/spec/jobs/cache/feed_job_spec.rb
@@ -78,6 +78,5 @@ RSpec.describe Cache::FeedJob do
         expect(subject.instance_variable_get(:@updated)).to eq(true)
       end
     end
-
   end
 end

--- a/spec/jobs/cache/feed_job_spec.rb
+++ b/spec/jobs/cache/feed_job_spec.rb
@@ -15,11 +15,13 @@ RSpec.describe Cache::FeedJob do
     <title>Example Channel</title>
     <link>http://example.com/</link>
     <description>My example channel</description>
+    <lastBuildDate>Mon, 22 May 2017 00:00:00 +0000</lastBuildDate>
     <item>
        <title>Example item</title>
        <link>http://example.com/item</link>
        <description>About the example item...</description>
        <content:encoded><![CDATA[<img src="http://www.example.com/image.png"/>]]></content:encoded>
+       <pubDate>Mon, 22 May 2017 00:00:00 +0000</pubDate>
     </item>
   </channel>
 </rss>
@@ -30,6 +32,8 @@ RSpec.describe Cache::FeedJob do
     subject.perform(url)
     expect(a_request(:get, url)).to have_been_made.at_least_once
   end
+
+
 
   it 'should cache the feed' do
     cache_key = "feed/#{url}"
@@ -48,5 +52,32 @@ RSpec.describe Cache::FeedJob do
       expect { subject.perform(url, true) }.to change { download_jobs.call.count }.by_at_least(1)
       expect(download_jobs.call.last.handler).to match(%r{http://www.example.com/image.png})
     end
+  end
+
+  context 'when the feed was previously cached' do
+    let(:cache_key) { "feed/#{url}" }
+    before do
+      Rails.cache.write(cache_key, Feedjira::Feed.parse(rss_body))
+    end
+
+    context 'when the last_modified date has NOT changed' do
+      it 'should not update the cache and @updated should be false' do
+        expect(Rails.cache).to_not receive(:write)
+        expect { subject.perform(url) }.to_not change { Rails.cache.fetch(cache_key) }
+        expect(subject.instance_variable_get(:@updated)).to_not eq(true)
+      end
+    end
+
+    context 'when the last_modified date has changed' do
+      before do
+        Rails.cache.write(cache_key, Feedjira::Feed.parse(rss_body.gsub('Mon, 22 May 2017', 'Tue, 23 May 2017')))
+      end
+
+      it 'should update the cache and @updated should be true' do
+        expect { subject.perform(url) }.to change { Rails.cache.fetch(cache_key) }
+        expect(subject.instance_variable_get(:@updated)).to eq(true)
+      end
+    end
+
   end
 end

--- a/spec/jobs/cache/feed_job_spec.rb
+++ b/spec/jobs/cache/feed_job_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Cache::FeedJob do
                 headers: { 'Content-Type' => 'application/rss+xml' })
   end
 
-  let(:url) { 'http://www.example.com/feed/' }
+  let(:url) { feeds(:all_blog).url }
   let(:rss_body) do
     <<-END
 <?xml version="1.0"?>

--- a/spec/models/feed_spec.rb
+++ b/spec/models/feed_spec.rb
@@ -69,4 +69,11 @@ RSpec.describe Feed do
       expect { subject.send(:queue_retrieval) }.to change { feed_jobs.call.count }.by(1)
     end
   end
+  
+  describe '#cache_key' do
+    let(:feed) { feeds(:fashion_tumblr) }
+    it 'should append "feed/" to the url' do
+      expect(feed.cache_key).to eq "feed/#{feed.url}"
+    end
+  end
 end

--- a/spec/models/feed_spec.rb
+++ b/spec/models/feed_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Feed do
       expect { subject.send(:queue_retrieval) }.to change { feed_jobs.call.count }.by(1)
     end
   end
-  
+
   describe '#cache_key' do
     let(:feed) { feeds(:fashion_tumblr) }
     it 'should append "feed/" to the url' do

--- a/spec/models/feed_spec.rb
+++ b/spec/models/feed_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Feed do
 
   describe '#cache_key' do
     let(:feed) { feeds(:fashion_tumblr) }
-    it 'should append "feed/" to the url' do
+    it 'should prepend "feed/" to the url' do
       expect(feed.cache_key).to eq "feed/#{feed.url}"
     end
   end


### PR DESCRIPTION
Change feed retrieval schedule to hourly.
Invalidate page cache when related feeds were updated.
Update the logic for invalidating caches to only happen when feeds actually changed, based on last_modified date.
 