### PR TITLE
Configurable additional locales

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -120,6 +120,10 @@
 ## deployed behind a reverse proxy.
 # HTTP_HOST=www.example.com
 
+## Additional locales to make available, comma-separated.
+## Default locales set in config/application.rb will still be available.
+# I18N_ADDITIONAL_LOCALES=cs,ga
+
 ## API key for localeapp.com, if you want to fetch localisation updates from
 ## there.
 # LOCALEAPP_API_KEY=

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/europeana/europeana-i18n-ruby.git
-  revision: 6211b28228d178232dd3c0f2de8231f1269f70c1
+  revision: e08006983556a49bbfb7003777ae4cab97f555f4
   branch: develop
   specs:
     europeana-i18n (0.0.1)

--- a/app/helpers/i18n_helper.rb
+++ b/app/helpers/i18n_helper.rb
@@ -1,36 +1,10 @@
 # frozen_string_literal: true
 
 module I18nHelper
-  def language_map
-    {
-      bg: 'bulgarian',
-      ca: 'catalan',
-      da: 'danish',
-      de: 'german',
-      el: 'greek',
-      en: 'english',
-      es: 'spanish',
-      et: 'estonian',
-      fi: 'finnish',
-      fr: 'french',
-      hr: 'croatian',
-      hu: 'hungarian',
-      it: 'italian',
-      lt: 'lithuanian',
-      lv: 'latvian',
-      mt: 'maltese',
-      no: 'norwegian',
-      nl: 'dutch',
-      pl: 'polish',
-      pt: 'portuguese',
-      ro: 'romanian',
-      ru: 'russian',
-      sv: 'swedish'
-    }
-  end
-
   def language_options_for_select
-    localised = language_map.map { |k, v| [t("global.language-#{v}", locale: k), k.to_s] }
+    localised = I18n.available_locales.map do |locale|
+      [t(locale, scope: 'global.languages', locale: locale), locale.to_s]
+    end
     localised.sort_by!(&:first)
     options_for_select(localised, I18n.locale.to_s)
   end

--- a/app/presenters/concerns/facet/labelling.rb
+++ b/app/presenters/concerns/facet/labelling.rb
@@ -146,15 +146,13 @@ module Facet
       # Makes use of both I18nData (https://github.com/grosser/i18n_data) and localeapp via I18n translations
       #
       # @return [String]
-      def language_facet_item_label(item)
-        language_code = item.dup
+      def language_facet_item_label(language_code)
         locale = I18n.locale == :no ? 'NN' : I18n.locale # The norwegian language file is named 'NN' not 'NO'
         i18ndata_label = I18nData.languages(locale)[language_code.upcase]
-        if i18ndata_label.blank?
-          I18n.t(language_code.to_sym, scope: 'global.facet.language', default: language_code.upcase)
-        else
-          i18ndata_label
-        end
+
+        return i18ndata_label unless i18ndata_label.blank?
+
+        I18n.t(language_code.to_sym, scope: 'global.languages', default: language_code.upcase)
       end
 
       ##

--- a/app/views/application_view.rb
+++ b/app/views/application_view.rb
@@ -100,7 +100,7 @@ class ApplicationView < Europeana::Styleguide::View
   end
 
   def alternate_language_links
-    language_map.keys.map do |locale|
+    I18n.available_locales.map do |locale|
       { rel: 'alternate', hreflang: locale, href: current_url_for_locale(locale) }
     end
   end

--- a/app/views/concerns/navigable_view.rb
+++ b/app/views/concerns/navigable_view.rb
@@ -206,8 +206,8 @@ module NavigableView
   end
 
   def utility_nav_items_submenu_items
-    language_map.map do |locale, i18n|
-      label = t("global.language-#{i18n}", locale: locale)
+    I18n.available_locales.map do |locale|
+      label = t(locale, scope: 'global.languages', locale: locale)
       link_item(label, current_url_for_locale(locale),
                 is_current: (locale.to_s == I18n.locale.to_s))
     end

--- a/config/initializers/env.rb
+++ b/config/initializers/env.rb
@@ -40,11 +40,3 @@ Rails.application.config.x.enable = OpenStruct.new(
   search_form_autocomplete: ENV['ENABLE_SEARCH_FORM_AUTOCOMPLETE'],
   entity_page: ENV['ENABLE_ENTITY_PAGE']
 )
-
-# Add locales to available locales
-if ENV['I18N_ADDITIONAL_LOCALES']
-  ENV['I18N_ADDITIONAL_LOCALES'].split(',').each do |locale|
-    Rails.application.config.i18n.available_locales << locale.to_sym
-  end
-  Rails.application.config.i18n.available_locales.sort!
-end

--- a/config/initializers/env.rb
+++ b/config/initializers/env.rb
@@ -40,3 +40,11 @@ Rails.application.config.x.enable = OpenStruct.new(
   search_form_autocomplete: ENV['ENABLE_SEARCH_FORM_AUTOCOMPLETE'],
   entity_page: ENV['ENABLE_ENTITY_PAGE']
 )
+
+# Add locales to available locales
+if ENV['I18N_ADDITIONAL_LOCALES']
+  ENV['I18N_ADDITIONAL_LOCALES'].split(',').each do |locale|
+    Rails.application.config.i18n.available_locales << locale.to_sym
+  end
+  Rails.application.config.i18n.available_locales.sort!
+end

--- a/config/initializers/i18n_available_locales.rb
+++ b/config/initializers/i18n_available_locales.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Add additional locales to I18n's available locales
+if ENV['I18N_ADDITIONAL_LOCALES']
+  Rails.application.config.i18n.available_locales.tap do |available_locales|
+    ENV['I18N_ADDITIONAL_LOCALES'].split(',').each do |locale|
+      available_locales << locale.to_sym
+    end
+
+    available_locales.sort!
+
+    counts = available_locales.each_with_object({}) do |locale, memo|
+      memo[locale] = memo.key?(locale) ? memo[locale] + 1 : 1
+    end
+
+    duplicate_locales = counts.select { |_locale, count| count > 1 }
+
+    if duplicate_locales.present?
+      fail 'Duplicate locales detected: ' + duplicate_locales.keys.map(&:to_s).join(',')
+    end
+  end
+end

--- a/spec/config/initializers/i18n_available_locales_spec.rb
+++ b/spec/config/initializers/i18n_available_locales_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+RSpec.describe 'I18n available locales initializer' do
+  subject { Rails.application.config.i18n.available_locales }
+
+  def read_initializer
+    @file_path ||= File.expand_path('../../../../config/initializers/i18n_available_locales.rb', __FILE__)
+    eval(File.open(File.expand_path(@file_path)).read)
+  end
+
+  context "when ENV['I18N_ADDITIONAL_LOCALES'] is set" do
+    let(:env_var) { 'cs' }
+    let(:default_locales) { %i(en de) }
+
+    before(:all) do
+      @additional_locales_was = ENV['I18N_ADDITIONAL_LOCALES'].dup
+      @available_locales_was = Rails.application.config.i18n.available_locales.dup
+    end
+
+    before(:each) do
+      ENV['I18N_ADDITIONAL_LOCALES'] = env_var.dup
+      Rails.application.config.i18n.available_locales = default_locales.dup
+    end
+
+    after(:all) do
+      ENV['I18N_ADDITIONAL_LOCALES'] = @additional_locales_was
+      Rails.application.config.i18n.available_locales = @available_locales_was
+    end
+
+    it 'adds locales to I18n' do |example|
+      read_initializer
+      expect(subject).to include(:cs)
+    end
+
+    it 'sorts locales' do
+      read_initializer
+      expect(subject.first).to eq(:cs)
+      expect(subject.last).to eq(:en)
+    end
+
+    context 'when there are duplicates' do
+      let(:env_var) { 'en,de' }
+      it 'fails' do
+        expect { read_initializer }.to raise_error('Duplicate locales detected: de,en')
+      end
+    end
+  end
+end

--- a/spec/config/initializers/i18n_available_locales_spec.rb
+++ b/spec/config/initializers/i18n_available_locales_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'I18n available locales initializer' do
       Rails.application.config.i18n.available_locales = @available_locales_was
     end
 
-    it 'adds locales to I18n' do |example|
+    it 'adds locales to I18n' do
       read_initializer
       expect(subject).to include(:cs)
     end

--- a/spec/presenters/facet/simple_presenter_spec.rb
+++ b/spec/presenters/facet/simple_presenter_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Facet::SimplePresenter, presenter: :facet do
         end
 
         it 'should use the I18nData translation' do
-          expect(I18n).to_not receive(:t).with(:nl, scope: 'global.facet.language', default: 'XY')
+          expect(I18n).to_not receive(:t).with(:nl, scope: 'global.languages', default: 'XY')
           expect(subject[:items].first[:text]).to eq 'Dutch; Flemish'
         end
       end
@@ -37,7 +37,7 @@ RSpec.describe Facet::SimplePresenter, presenter: :facet do
         context 'when the value is in localeapp' do
           before do
             allow(I18n).to receive(:t) { 'default translation' }
-            allow(I18n).to receive(:t).with(:xy, scope: 'global.facet.language', default: 'XY') { 'Localeapp Dutch' }
+            allow(I18n).to receive(:t).with(:xy, scope: 'global.languages', default: 'XY') { 'Localeapp Dutch' }
           end
           it 'should use the localeapp translation' do
             expect(subject[:items].first[:text]).to eq 'Localeapp Dutch'

--- a/spec/support/shared_examples/common_view_components.rb
+++ b/spec/support/shared_examples/common_view_components.rb
@@ -1,6 +1,6 @@
 RSpec.shared_examples 'common view components', :common_view_components do
   let(:available_locales) do
-    [:bg, :ca, :da, :de, :el, :en, :es, :fi, :fr, :hr, :hu, :it, :lt, :lv, :nl, :pl, :pt, :ro, :ru, :sv]
+    I18n.available_locales
   end
 
   it 'should have site name in <title>' do
@@ -62,14 +62,9 @@ RSpec.shared_examples 'common view components', :common_view_components do
   end
 
   it 'should have language menu links to all locales' do
-    class AvailableLocales
-      include I18nHelper
-    end
-    language_map = AvailableLocales.new.language_map
-
     render
     available_locales.each do |locale|
-      label = I18n.t("global.language-#{language_map[locale]}", locale: locale)
+      label = I18n.t(locale, scope: 'global.languages', locale: locale)
       expect(rendered).to have_selector('#settings-menu a', text: label)
     end
   end


### PR DESCRIPTION
Re: https://europeanadev.assembla.com/spaces/europeana-npc/tickets/2338

* Additional locales can be specified in the env var `I18N_ADDITIONAL_LOCALES` (see .env.example)
* Language name lookups are moved to the I18n scope `global.languages`