### PR TITLE
re: #2404 new irish translations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'rails', '4.2.7.1'
 
 gem 'europeana-styleguide', github: 'europeana/europeana-styleguide-ruby', ref: '03fc544'
 
-gem 'europeana-i18n', github: 'europeana/europeana-i18n-ruby', branch: 'hotfix/2399-gaeilge'
+gem 'europeana-i18n', github: 'europeana/europeana-i18n-ruby', branch: 'hotfix/2404-irish-translations'
 
 # Lock Mustache at 1.0.3 because > 1.0.3 kills item page performance with the commit
 # https://github.com/mustache/mustache/commit/3c7af8f33d0c3b04c159e10e73a2831cf1e56e02

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/europeana/europeana-i18n-ruby.git
-  revision: ec86668514beb9a6c63e46e568d7092cb1285ff2
+  revision: 3c792f0d4985bafc3d214923a8092100590a8de6
   branch: hotfix/2404-irish-translations
   specs:
     europeana-i18n (0.0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: git://github.com/europeana/europeana-i18n-ruby.git
-  revision: 7e217d3ea07c404bebf3c4a22e52e4f6320d28f1
-  branch: hotfix/2399-gaeilge
+  revision: 55070350be08944c9084fbc0e1dd71356328283c
+  branch: hotfix/2404-irish-translations
   specs:
     europeana-i18n (0.0.1)
       rails (>= 4.0, < 6.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/europeana/europeana-i18n-ruby.git
-  revision: 55070350be08944c9084fbc0e1dd71356328283c
+  revision: ec86668514beb9a6c63e46e568d7092cb1285ff2
   branch: hotfix/2404-irish-translations
   specs:
     europeana-i18n (0.0.1)


### PR DESCRIPTION
This uses the a branch from the [europeana-i8n gem](https://github.com/europeana/europeana-i18n-ruby) to only cherry-pick new Irish translations into the previously released version.