### PR TITLE
add api_url to media_proxy params

### DIFF
--- a/app/helpers/api_helper.rb
+++ b/app/helpers/api_helper.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module ApiHelper
   def api_url
     params[:api_url] || Europeana::API.url

--- a/app/helpers/media_proxy_helper.rb
+++ b/app/helpers/media_proxy_helper.rb
@@ -1,12 +1,15 @@
 # frozen_string_literal: true
 
 module MediaProxyHelper
+  include ApiHelper
+
   def media_proxy_configured?
     Rails.application.config.x.europeana_media_proxy.present?
   end
 
   def media_proxy_url(record_id, web_resource_url)
     return web_resource_url unless media_proxy_configured?
-    Rails.application.config.x.europeana_media_proxy + record_id + '?view=' + CGI.escape(web_resource_url)
+    proxy_params = { view: web_resource_url, api_url: api_url }
+    Rails.application.config.x.europeana_media_proxy + record_id + '?' + proxy_params.to_query
   end
 end

--- a/spec/helpers/media_proxy_helper_spec.rb
+++ b/spec/helpers/media_proxy_helper_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe MediaProxyHelper do
     context 'when media proxy is configured' do
       let(:europeana_media_proxy) { 'http://proxy.example.com' }
       it 'should use media proxy' do
-        expect(subject).to eq('http://proxy.example.com/abc/123?view=http%3A%2F%2Fwww.example.com%2Fimage.jpg')
+        expect(subject).to eq('http://proxy.example.com/abc/123?api_url=' + CGI.escape(api_url) + '&view=http%3A%2F%2Fwww.example.com%2Fimage.jpg')
       end
     end
 


### PR DESCRIPTION
add the api_url parameter to media_proxy requests in order to identify requests to proxy media not yet in production