### PR TITLE
Fetch dataProvider direct from document

### DIFF
--- a/app/presenters/concerns/blacklight_document_presenter.rb
+++ b/app/presenters/concerns/blacklight_document_presenter.rb
@@ -25,12 +25,10 @@ module BlacklightDocumentPresenter
   end
 
   def field_value(fields, **options)
-    unescape = options[:unescape]
     method = options[:context] == :index ? :render_index_field_value : :render_document_show_field_value
 
     [fields].flatten.each do |field|
-      value = blacklight_document_presenter.send(method, field, options.except(:context, :unescape))
-      value = CGI.unescapeHTML(value.to_str) if unescape
+      value = blacklight_document_presenter.send(method, field, options.except(:context))
       return value unless value.blank?
     end
 

--- a/app/presenters/concerns/blacklight_document_presenter.rb
+++ b/app/presenters/concerns/blacklight_document_presenter.rb
@@ -17,8 +17,7 @@ module BlacklightDocumentPresenter
     #
     # @see Blacklight::DocumentPresenter#render_values
     def render_values(values, field_config = nil)
-      options = {}
-      options = field_config.separator_options if field_config && field_config.separator_options
+      options = field_config&.separator_options || {}
 
       values.to_sentence(options)
     end

--- a/app/presenters/concerns/blacklight_document_presenter.rb
+++ b/app/presenters/concerns/blacklight_document_presenter.rb
@@ -8,18 +8,20 @@ module BlacklightDocumentPresenter
   end
 
   def blacklight_document_presenter
-    @blacklight_document_presenter ||= Europeana::Blacklight::DocumentPresenter.new(document, controller)
+    @blacklight_document_presenter ||= NoEscapePresenter.new(document, controller)
   end
 
-  ##
-  # Override to prevent HTML escaping, handled by {Mustache}
-  #
-  # @see Blacklight::DocumentPresenter#render_values
-  def render_values(values, field_config = nil)
-    options = {}
-    options = field_config.separator_options if field_config && field_config.separator_options
+  class NoEscapePresenter < Europeana::Blacklight::DocumentPresenter
+    ##
+    # Override to prevent HTML escaping, handled by {Mustache}
+    #
+    # @see Blacklight::DocumentPresenter#render_values
+    def render_values(values, field_config = nil)
+      options = {}
+      options = field_config.separator_options if field_config && field_config.separator_options
 
-    values.to_sentence(options)
+      values.to_sentence(options)
+    end
   end
 
   def field_value(fields, **options)

--- a/app/presenters/document/record_presenter.rb
+++ b/app/presenters/document/record_presenter.rb
@@ -15,6 +15,23 @@ module Document
       @controller = controller
     end
 
+    def title
+      @title ||= [display_title, creator_title].compact.join(' | ')
+    end
+
+    def display_title
+      field_value('proxies.dcTitle') ||
+        truncate(field_value('proxies.dcDescription'), length: 200, separator: ' ')
+    end
+
+    def creator_title
+      @creator_title ||= begin
+        document.fetch('agents.prefLabel', []).first ||
+          field_value('dcCreator') ||
+          field_value('proxies.dcCreator')
+      end
+    end
+
     def edm_is_shown_at
       @edm_is_shown_at ||= aggregation.fetch('edmIsShownAt', nil)
     end

--- a/app/presenters/document/record_presenter.rb
+++ b/app/presenters/document/record_presenter.rb
@@ -4,6 +4,7 @@ module Document
   ##
   # Blacklight document presenter for a Europeana record
   class RecordPresenter < ApplicationPresenter
+    include ActionView::Helpers::TextHelper
     include BlacklightDocumentPresenter
     include Record::IIIF
     include Metadata::Rights

--- a/app/presenters/document/search_result_presenter.rb
+++ b/app/presenters/document/search_result_presenter.rb
@@ -73,7 +73,7 @@ module Document
 
     def origin
       {
-        text: field_value('dataProvider'),
+        text: document.fetch('dataProvider', []).first,
         url: field_value('edmIsShownAt')
       }
     end

--- a/app/presenters/document/search_result_presenter.rb
+++ b/app/presenters/document/search_result_presenter.rb
@@ -50,7 +50,7 @@ module Document
     end
 
     def title
-      truncate(field_value(%w(dcTitleLangAware title), unescape: true),
+      truncate(field_value(%w(dcTitleLangAware title)),
                length: 225,
                separator: ' ',
                escape: false)
@@ -58,7 +58,7 @@ module Document
 
     def text
       {
-        medium: truncate(field_value(%w(dcDescriptionLangAware dcDescription), unescape: true),
+        medium: truncate(field_value(%w(dcDescriptionLangAware dcDescription)),
                          length: 277,
                          separator: ' ',
                          escape: false)
@@ -73,7 +73,7 @@ module Document
 
     def origin
       {
-        text: document.fetch('dataProvider', []).first,
+        text: field_value('dataProvider'),
         url: field_value('edmIsShownAt')
       }
     end

--- a/app/views/portal/show.rb
+++ b/app/views/portal/show.rb
@@ -40,7 +40,7 @@ module Portal
     def head_meta
       mustache[:head_meta] ||= begin
         landing = field_value('europeanaAggregation.edmLandingPage')
-        preview = helpers.thumbnail_url_for_edm_preview(field_value('europeanaAggregation.edmPreview', unescape: true))
+        preview = helpers.thumbnail_url_for_edm_preview(field_value('europeanaAggregation.edmPreview'))
 
         head_meta = [
           { meta_name: 'description', content: meta_description },
@@ -57,10 +57,7 @@ module Portal
     end
 
     def page_content_heading
-      mustache[:page_content_heading] ||= begin
-        title = [display_title, creator_title]
-        CGI.unescapeHTML(title.compact.join(' | '))
-      end
+      presenter.title
     end
 
     def navigation
@@ -82,7 +79,7 @@ module Portal
         {
           object: {
             annotations_later: true, # TODO: remove when styleguide assumes this
-            creator: creator_title,
+            creator: presenter.creator_title,
             concepts: presenter.field_group(:concepts),
             copyright: presenter.field_group(:copyright),
             creation_date: field_value('proxies.dctermsCreated'),
@@ -97,7 +94,7 @@ module Portal
             rights: simple_rights_label_data,
             social_share: social_share,
             subtitle: document.fetch('proxies.dctermsAlternative', []).first || document.fetch(:title, [])[1],
-            title: page_content_heading,
+            title: presenter.title,
             type: field_value('proxies.dcType')
           },
           refs_rels: presenter.field_group(:refs_rels),
@@ -259,7 +256,7 @@ module Portal
 
     def og_description
       mustache[:og_description] ||= begin
-        description = field_value('proxies.dcDescription', unescape: true)
+        description = field_value('proxies.dcDescription')
         if description.present?
           truncate(description.split('.').first(3).join('.'), length: 200)
         else
@@ -270,7 +267,7 @@ module Portal
 
     def og_title
       mustache[:og_title] ||= begin
-        field_value('proxies.dcTitle', unescape: true) ||
+        field_value('proxies.dcTitle') ||
           field_value('proxies.dctermsAlternative') ||
           field_value('proxies.dcDescription') ||
           field_value('proxies.dcIdentifier')
@@ -308,19 +305,6 @@ module Portal
         field_value('proxies.dcTitle')
       else
         title.first
-      end
-    end
-
-    def display_title
-      field_value('proxies.dcTitle') ||
-        truncate(field_value('proxies.dcDescription'), length: 200, separator: ' ')
-    end
-
-    def creator_title
-      @creator_title ||= begin
-        document.fetch('agents.prefLabel', []).first ||
-          field_value('dcCreator') ||
-          field_value('proxies.dcCreator')
       end
     end
 


### PR DESCRIPTION
To prevent double HTML escaping in combination with Blacklight.

Re: https://europeana.atlassian.net/browse/EC-2524