### PR TITLE
Switch to ActiveRecord for session storage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'mustache', '1.0.3'
 gem 'stache', git: 'https://github.com/europeana/stache.git', branch: 'europeana-styleguide'
 
 gem 'aasm', '~> 4.2'
+gem 'activerecord-session_store'
 gem 'blacklight', '~> 6.0.0'
 gem 'acts_as_list', '~> 0.7'
 gem 'cancancan', '~> 1.12'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,12 @@ GEM
       activemodel (= 4.2.9)
       activesupport (= 4.2.9)
       arel (~> 6.0)
+    activerecord-session_store (1.1.0)
+      actionpack (>= 4.0, < 5.2)
+      activerecord (>= 4.0, < 5.2)
+      multi_json (~> 1.11, >= 1.11.2)
+      rack (>= 1.5.2, < 3)
+      railties (>= 4.0, < 5.2)
     activesupport (4.2.9)
       i18n (~> 0.7)
       minitest (~> 5.1)
@@ -516,6 +522,7 @@ PLATFORMS
 
 DEPENDENCIES
   aasm (~> 4.2)
+  activerecord-session_store
   acts_as_list (~> 0.7)
   blacklight (~> 6.0.0)
   cancancan (~> 1.12)

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
-# Be sure to restart your server when you modify this file.
+# frozen_string_literal: true
 
-Rails.application.config.session_store :cookie_store, key: '_portal_session'
+Rails.application.config.session_store :active_record_store, key: '_europeana_portal_session'

--- a/db/migrate/20171121121759_add_sessions_table.rb
+++ b/db/migrate/20171121121759_add_sessions_table.rb
@@ -1,0 +1,12 @@
+class AddSessionsTable < ActiveRecord::Migration
+  def change
+    create_table :sessions do |t|
+      t.string :session_id, :null => false
+      t.text :data
+      t.timestamps
+    end
+
+    add_index :sessions, :session_id, :unique => true
+    add_index :sessions, :updated_at
+  end
+end

--- a/db/migrate/20171121121759_add_sessions_table.rb
+++ b/db/migrate/20171121121759_add_sessions_table.rb
@@ -1,12 +1,14 @@
+# frozen_string_literal: true
+
 class AddSessionsTable < ActiveRecord::Migration
   def change
     create_table :sessions do |t|
-      t.string :session_id, :null => false
+      t.string :session_id, null: false
       t.text :data
       t.timestamps
     end
 
-    add_index :sessions, :session_id, :unique => true
+    add_index :sessions, :session_id, unique: true
     add_index :sessions, :updated_at
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171018122656) do
+ActiveRecord::Schema.define(version: 20171121121759) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "hstore"
+  enable_extension "pg_stat_statements"
+  enable_extension "unaccent"
 
   create_table "banner_translations", force: :cascade do |t|
     t.integer  "banner_id",              null: false
@@ -338,6 +341,16 @@ ActiveRecord::Schema.define(version: 20171018122656) do
   end
 
   add_index "searches", ["user_id"], name: "index_searches_on_user_id", using: :btree
+
+  create_table "sessions", force: :cascade do |t|
+    t.string   "session_id", null: false
+    t.text     "data"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "sessions", ["session_id"], name: "index_sessions_on_session_id", unique: true, using: :btree
+  add_index "sessions", ["updated_at"], name: "index_sessions_on_updated_at", using: :btree
 
   create_table "topic_translations", force: :cascade do |t|
     t.integer  "topic_id",   null: false

--- a/lib/clock.rb
+++ b/lib/clock.rb
@@ -3,8 +3,10 @@
 require File.expand_path('../../config/boot', __FILE__)
 require File.expand_path('../../config/environment', __FILE__)
 require 'clockwork'
+require 'rake'
 
 include Clockwork
+Rails.application.load_tasks
 
 unless ENV['DISABLE_SCHEDULED_JOBS']
   every(1.hour, 'cache.feed.custom') do
@@ -42,6 +44,7 @@ unless ENV['DISABLE_SCHEDULED_JOBS']
   end
 
   every(1.day, 'db.sweeper', at: ENV['SCHEDULE_DB_SWEEPER']) do
+    Rake::Task['db:sessions:trim'].invoke # from activerecord-session_store
     DeleteOldSearchesJob.perform_later
   end
 end

--- a/spec/config/initializers/session_store_spec.rb
+++ b/spec/config/initializers/session_store_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+describe Rails.application.config.session_store do
+  it 'uses ActionDispatch::Session::ActiveRecordStore' do
+    expect(Rails.application.config.session_store).to eq(ActionDispatch::Session::ActiveRecordStore)
+  end
+
+  it 'has key "_europeana_portal_session"' do
+    expect(Rails.application.config.session_options[:key]).to eq('_europeana_portal_session')
+  end
+end


### PR DESCRIPTION
Re: https://europeana.atlassian.net/browse/EC-2520

Because some model validation flash messages get too long for cookie storage.