### PR TITLE
use "; " as a separator for field values

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/europeana/europeana-i18n-ruby.git
-  revision: d5e7fafd2ae5a1588eafdb21bbcc3c4baa3fe143
+  revision: 7c96b14f0853865c8cf8687d1bd787d5b3d4dbc1
   branch: develop
   specs:
     europeana-i18n (0.0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/europeana/europeana-i18n-ruby.git
-  revision: 7c96b14f0853865c8cf8687d1bd787d5b3d4dbc1
+  revision: 33363b9b5b8b8ae32387e3eb7e4d6368f999fb41
   branch: develop
   specs:
     europeana-i18n (0.0.1)

--- a/app/presenters/concerns/blacklight_document_presenter.rb
+++ b/app/presenters/concerns/blacklight_document_presenter.rb
@@ -5,6 +5,7 @@ module BlacklightDocumentPresenter
 
   included do
     delegate :render_field_value, to: :blacklight_document_presenter
+    #delegate :t, to: I18n
   end
 
   def blacklight_document_presenter
@@ -17,7 +18,7 @@ module BlacklightDocumentPresenter
     #
     # @see Blacklight::DocumentPresenter#render_values
     def render_values(values, _field_config = nil)
-      values.join('; ')
+      values.join(t('global.punctuation.list-item-separator'))
     end
   end
 

--- a/app/presenters/concerns/blacklight_document_presenter.rb
+++ b/app/presenters/concerns/blacklight_document_presenter.rb
@@ -16,10 +16,8 @@ module BlacklightDocumentPresenter
     # Override to prevent HTML escaping, handled by {Mustache}
     #
     # @see Blacklight::DocumentPresenter#render_values
-    def render_values(values, field_config = nil)
-      options = field_config&.separator_options || {}
-
-      values.to_sentence(options)
+    def render_values(values, _field_config = nil)
+      values.join('; ')
     end
   end
 

--- a/app/presenters/concerns/blacklight_document_presenter.rb
+++ b/app/presenters/concerns/blacklight_document_presenter.rb
@@ -5,7 +5,6 @@ module BlacklightDocumentPresenter
 
   included do
     delegate :render_field_value, to: :blacklight_document_presenter
-    #delegate :t, to: I18n
   end
 
   def blacklight_document_presenter
@@ -13,6 +12,8 @@ module BlacklightDocumentPresenter
   end
 
   class NoEscapePresenter < Europeana::Blacklight::DocumentPresenter
+    delegate :t, to: I18n
+
     ##
     # Override to prevent HTML escaping, handled by {Mustache}
     #


### PR DESCRIPTION
re EC-2497
