### PR TITLE
Nullify gallery published_by when user is deleted

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,7 +27,7 @@ class User < ActiveRecord::Base
   delegate :can?, :cannot?, to: :ability
   delegate :role_enum, to: :class
 
-  has_many :galleries, inverse_of: :publisher, foreign_key: :published_by
+  has_many :galleries, inverse_of: :publisher, foreign_key: :published_by, dependent: :nullify
 
   class << self
     def role_enum


### PR DESCRIPTION
To prevent FK constraint exceptions when deleting users who published galleries.