### PR TITLE
Optimise facet URL generation

### DIFF
--- a/app/presenters/facet/boolean_presenter.rb
+++ b/app/presenters/facet/boolean_presenter.rb
@@ -14,19 +14,19 @@ module Facet
     end
 
     def facet_url
-      if boolean_facet_in_params?(@facet.name)
-        search_action_url(remove_facet_params(facet_params(@facet.name).first))
+      if boolean_facet_in_params?(facet_name)
+        remove_facet_url(facet_params(facet_name).first)
       elsif facet_checked?
-        search_action_url(search_state.add_facet_params_and_redirect(@facet.name, facet_config.boolean[:off]))
+        add_facet_url(facet_config.boolean[:off])
       else
-        search_action_url(search_state.add_facet_params_and_redirect(@facet.name, facet_config.boolean[:on]))
+        add_facet_url(facet_config.boolean[:on])
       end
     end
 
     def facet_checked?
-      if facet_config.boolean[:on].nil? && !boolean_facet_in_params?(@facet.name)
+      if facet_config.boolean[:on].nil? && !boolean_facet_in_params?(facet_name)
         true
-      elsif !facet_config.boolean[:on].nil? && facet_in_params?(@facet.name, facet_config.boolean[:on])
+      elsif !facet_config.boolean[:on].nil? && facet_in_params?(facet_name, facet_config.boolean[:on])
         true
       else
         facet_config.boolean[:default] == :on

--- a/app/presenters/facet/collection_presenter.rb
+++ b/app/presenters/facet/collection_presenter.rb
@@ -4,21 +4,14 @@ module Facet
   class CollectionPresenter < SimplePresenter
     def add_facet_url(item)
       value = facet_value_for_facet_item(item)
-
       base_url = default_facet_value?(value) ? search_url : collection_url(value)
-      [base_url, add_facet_base_query].join('?')
+      [base_url, facet_item_url_base_query].join('?')
     end
 
-    ##
-    # Removing the collection facet only works when in a collection,
-    # as it redirects to the standard search.
-    # The only reason it takes a facet_item as a param is because
-    # this overrides {FacetPresenter}
-    #
-    # @param see {#facet_item}
-    # @return [Hash] Request parameters without the collection
-    def remove_facet_params(_item)
-      params.except(:id).merge(controller: :portal, action: :index)
+    # TODO: is this useful behaviour when the collection facet is presented
+    #       like a radio button where one is always selected?
+    def remove_facet_url(_item)
+      [search_url, facet_item_url_base_query].reject(&:blank?).join('?')
     end
 
     def filter_items

--- a/app/presenters/facet/collection_presenter.rb
+++ b/app/presenters/facet/collection_presenter.rb
@@ -2,14 +2,11 @@
 
 module Facet
   class CollectionPresenter < SimplePresenter
-    def add_facet_params(item)
+    def add_facet_url(item)
       value = facet_value_for_facet_item(item)
 
-      if default_facet_value?(value)
-        params.except(:id).merge(controller: :portal, action: :index)
-      else
-        params.merge(controller: :collections, action: :show, id: value)
-      end
+      base_url = default_facet_value?(value) ? search_url : collection_url(value)
+      [base_url, add_facet_base_query].join('?')
     end
 
     ##

--- a/app/presenters/facet/collection_presenter.rb
+++ b/app/presenters/facet/collection_presenter.rb
@@ -8,8 +8,6 @@ module Facet
       [base_url, facet_item_url_base_query].join('?')
     end
 
-    # TODO: is this useful behaviour when the collection facet is presented
-    #       like a radio button where one is always selected?
     def remove_facet_url(_item)
       [search_url, facet_item_url_base_query].reject(&:blank?).join('?')
     end
@@ -34,14 +32,6 @@ module Facet
 
     def facet_params(_field)
       params[:controller] == 'collections' ? params[:id] : default_facet_value
-    end
-
-    def ordered(*)
-      super.tap do |items|
-        if all = items.detect { |item| default_facet_value?(facet_value_for_facet_item(item)) }
-          items.unshift(items.delete(all))
-        end
-      end
     end
   end
 end

--- a/app/presenters/facet/hierarchical_presenter.rb
+++ b/app/presenters/facet/hierarchical_presenter.rb
@@ -48,8 +48,8 @@ module Facet
     def remove_facet_query(item)
       super.tap do |query|
         item_children(item).each do |child|
-          child_query = CGI.escape("f[#{child.name}][]")
-          query.gsub!(/#{child_query}=[^&]+&?/, '')
+          child_query_key = Regexp.escape(CGI.escape("f[#{child.name}][]"))
+          query.gsub!(/#{child_query_key}=[^&]+&?/, '')
         end
       end
     end

--- a/app/presenters/facet/hierarchical_presenter.rb
+++ b/app/presenters/facet/hierarchical_presenter.rb
@@ -44,14 +44,12 @@ module Facet
     end
 
     ##
-    # Removes all child facets from params
-    def remove_facet_params(item)
-      super.tap do |p|
-        if p.key?(:f)
-          item_children(item).each do |child|
-            p[:f].delete(child.name)
-          end
-          p.delete(:f) if p[:f].empty?
+    # Removes all child facets from query string
+    def remove_facet_query(item)
+      super.tap do |query|
+        item_children(item).each do |child|
+          child_query = CGI.escape("f[#{child.name}][]")
+          query.gsub!(/#{child_query}=[^&]+&?/, '')
         end
       end
     end

--- a/app/presenters/facet_presenter.rb
+++ b/app/presenters/facet_presenter.rb
@@ -179,7 +179,7 @@ class FacetPresenter < ApplicationPresenter
   #
   # @return [String] Request query string without the given facet item
   def remove_facet_query(item)
-    item_query = facet_cgi_query(facet_name, item.respond_to?(:value) ? item.value : item)
+    item_query = Regexp.escape(facet_cgi_query(facet_name, item.respond_to?(:value) ? item.value : item))
     facet_item_url_base_query.dup.sub(/#{item_query}&?/, '')
   end
 

--- a/app/presenters/facet_presenter.rb
+++ b/app/presenters/facet_presenter.rb
@@ -193,14 +193,13 @@ class FacetPresenter < ApplicationPresenter
   end
 
   def build_add_facet_parent_query
-    if @parent && facet_config.parent
-      parent_facet = facet_config.parent.is_a?(Array) ? facet_config.parent.first : facet_config.parent
-      unless facet_in_params?(parent_facet, @parent)
-        return facet_cgi_query(parent_facet, @parent.value)
-      end
-    end
+    return nil unless parent_facet.present?
 
-    nil
+    facet_in_params?(parent_facet, @parent) ? nil : facet_cgi_query(parent_facet, @parent.value)
+  end
+
+  def parent_facet
+    @parent_facet ||= facet_config.parent.is_a?(Array) ? facet_config.parent.first : facet_config.parent
   end
 
   def add_facet_url(item)

--- a/app/presenters/facet_presenter.rb
+++ b/app/presenters/facet_presenter.rb
@@ -189,17 +189,18 @@ class FacetPresenter < ApplicationPresenter
 
   def add_facet_parent_query
     return @add_facet_parent_query if instance_variable_defined?(:@add_facet_parent_query)
+    @add_facet_parent_query = build_add_facet_parent_query
+  end
 
-    @add_facet_parent_query = nil
-
+  def build_add_facet_parent_query
     if @parent && facet_config.parent
       parent_facet = facet_config.parent.is_a?(Array) ? facet_config.parent.first : facet_config.parent
       unless facet_in_params?(parent_facet, @parent)
-        @add_facet_parent_query = facet_cgi_query(parent_facet, @parent.value)
+        return facet_cgi_query(parent_facet, @parent.value)
       end
     end
 
-    @add_facet_parent_query
+    nil
   end
 
   def add_facet_url(item)

--- a/spec/support/shared_contexts/facet_presenter.rb
+++ b/spec/support/shared_contexts/facet_presenter.rb
@@ -6,7 +6,7 @@ RSpec.shared_context 'facet presenter', presenter: :facet do
       hits = (count + 1 - n) * 100
       value = case item_type
               when :text
-                "Item#{n}"
+                "Item #{n}"
               when :number
                 n
               else

--- a/spec/support/shared_examples/facet_presenter.rb
+++ b/spec/support/shared_examples/facet_presenter.rb
@@ -59,7 +59,7 @@ shared_examples 'a facet presenter' do
     end
 
     it 'should include URL to remove facet' do
-      expect(subject[:remove]).not_to match(facet.name)
+      expect(subject[:remove]).not_to include(facet.name)
     end
 
     it 'should include facet URL param name' do


### PR DESCRIPTION
Using `String` because using `Blacklight::SearchState` and `Hash` is too expensive for large numbers of facet values.