### PR TITLE
Make record sets positionable

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,3 @@
-
 GIT
   remote: https://github.com/europeana/europeana-i18n-ruby.git
   revision: 6a98bafa8b8a8c8c71745274f379d33d9daa7e10
@@ -74,7 +73,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    acts_as_list (0.9.7)
+    acts_as_list (0.9.15)
       activerecord (>= 3.0)
     addressable (2.5.1)
       public_suffix (~> 2.0, >= 2.0.2)

--- a/app/models/europeana/record/set.rb
+++ b/app/models/europeana/record/set.rb
@@ -29,6 +29,12 @@ module Europeana
         europeana_ids&.map { |id| Europeana::Record.portal_url(id) }
       end
 
+      delegate :position, to: :page_element, allow_nil: true
+
+      def position=(value)
+        page_element&.update_attribute(:position, value.to_i)
+      end
+
       # Set Europeana IDs from portal URLs
       #
       # @param value [Array<String>]

--- a/app/models/page_element.rb
+++ b/app/models/page_element.rb
@@ -3,7 +3,9 @@
 class PageElement < ActiveRecord::Base
   belongs_to :page, inverse_of: :elements, touch: true
   belongs_to :positionable, polymorphic: true
-  acts_as_list scope: %i(page positionable)
+  acts_as_list scope: %i(page_id positionable_type)
+
+  validates :page, :positionable, presence: true
 
   after_save do
     page.touch

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -195,6 +195,7 @@ RailsAdmin.config do |config|
 
     edit do
       field :pref_label
+      field :position, :hidden
       field :portal_urls_text, :text do
         required true
         html_attributes rows: 15, cols: 80

--- a/spec/models/europeana/record/set_spec.rb
+++ b/spec/models/europeana/record/set_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe Europeana::Record::Set do
   it { is_expected.to validate_presence_of(:europeana_ids) }
   it { is_expected.to validate_presence_of(:pref_label) }
 
+  it { is_expected.to delegate_method(:position).to(:page_element) }
+
   it { is_expected.to have_array_of_strings_attribute(:portal_urls).elements(valid_portal_urls) }
   it { is_expected.to have_array_of_strings_attribute(:alt_label) }
 
@@ -183,6 +185,15 @@ RSpec.describe Europeana::Record::Set do
       valid_portal_urls.each do |valid_portal_url|
         expect(subject.errors[:portal_urls_text].none? { |error| error.include?(valid_portal_url) }).to be true
       end
+    end
+  end
+
+  describe '#position=' do
+    it 'updates position on page element' do
+      subject.save!
+      old_position = subject.page_element.position
+      new_position = old_position + 1
+      expect { subject.position = new_position }.to change { subject.page_element.position }.to(new_position)
     end
   end
 end


### PR DESCRIPTION
The tabbed association objects in RailsAdmin are already sortable with jQuery UI Sortable, and we already have [custom JS](https://github.com/europeana/europeana-portal-collections/blob/develop/app/assets/javascripts/rails_admin/custom/ui.js) to apply the  sorting to a `position` field if present on the nested form.

This works by delegating position from the record set to the joining page element. The caveat is that it does not work for new record sets, which will always be added to the end of the list when the page is saved, but may subsequently be ordered.