### PR TITLE
Declare model class in migration

### DIFF
--- a/db/migrate/20180427125141_add_image_portal_urls_to_gallery.rb
+++ b/db/migrate/20180427125141_add_image_portal_urls_to_gallery.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddImagePortalUrlsToGallery < ActiveRecord::Migration
   def change
     add_column :galleries, :image_portal_urls, :string, array: true

--- a/db/migrate/20180430075313_add_image_errors_to_gallery.rb
+++ b/db/migrate/20180430075313_add_image_errors_to_gallery.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddImageErrorsToGallery < ActiveRecord::Migration
   def change
     add_column :galleries, :image_errors, :jsonb

--- a/db/migrate/20180625102705_create_europeana_record_sets.rb
+++ b/db/migrate/20180625102705_create_europeana_record_sets.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 class CreateEuropeanaRecordSets < ActiveRecord::Migration
+  class Europeana::Record::Set < ActiveRecord::Base
+    self.table_name = 'europeana_record_sets'
+    translates :title
+  end
+
   def change
     create_table :europeana_record_sets do |t|
       t.string :europeana_ids, array: true, null: false


### PR DESCRIPTION
To prevent migration failure from schema version 20180430075313 to 20180730121538 on this branch.