### PR TITLE
Pseudo-facet API toggle for newspapers collection

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/europeana/europeana-i18n-ruby.git
-  revision: 2e9270e910ff377bfa90ffb701033dcdc0275def
+  revision: 37f1d97c7b571cc16f296bb197cfe41731fa2316
   branch: develop
   specs:
     europeana-i18n (0.1.1)

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -4,6 +4,7 @@
 # Provides Blacklight search and browse, within a content Collection
 class CollectionsController < ApplicationController
   include Europeana::Collections
+  include FacetsHelper
   include RecordCountsHelper
   include SearchInteractionLogging
 
@@ -58,7 +59,9 @@ class CollectionsController < ApplicationController
   end
 
   def collection_api_url?
-    @collection.api_url.present?
+    return false unless @collection.api_url.present?
+    return false unless blacklight_config.facet_fields.key?('api')
+    !facet_in_params?('api', 'default')
   end
 
   def find_collection

--- a/app/controllers/concerns/blacklight_config.rb
+++ b/app/controllers/concerns/blacklight_config.rb
@@ -62,7 +62,8 @@ module BlacklightConfig
 
       # Facet fields in the order they should be displayed.
       config.add_facet_field 'COLLECTION', include_in_request: false, single: true,
-                             values: ->(context) { context.displayable_collections.map { |collection| collection.key }.unshift('all') }
+                             values: ->(context) { context.displayable_collections.map { |collection| collection.key }.unshift('all') },
+                             default: 'all'
       config.add_facet_field 'api', include_in_request: false, single: true,
                              when: ->(context) { context.within_collection? && context.current_collection.key == 'newspapers' },
                              values: %w(collection default),

--- a/app/controllers/concerns/blacklight_config.rb
+++ b/app/controllers/concerns/blacklight_config.rb
@@ -61,7 +61,12 @@ module BlacklightConfig
       config.add_index_field 'edmIsShownAt'
 
       # Facet fields in the order they should be displayed.
-      config.add_facet_field 'COLLECTION', include_in_request: false, single: true
+      config.add_facet_field 'COLLECTION', include_in_request: false, single: true,
+                             values: ->(context) { context.displayable_collections.map { |collection| collection.key }.unshift('all') }
+      config.add_facet_field 'api', include_in_request: false, single: true,
+                             when: ->(context) { context.within_collection? && context.current_collection.key == 'newspapers' },
+                             values: %w(collection default),
+                             default: 'collection'
       config.add_facet_field 'TYPE', hierarchical: true
       config.add_facet_field 'IMAGE_COLOUR', parent: %w(TYPE IMAGE)
       config.add_facet_field 'COLOURPALETTE', colour: true, hierarchical: true, parent: %w(TYPE IMAGE), limit: 20

--- a/app/controllers/concerns/blacklight_config.rb
+++ b/app/controllers/concerns/blacklight_config.rb
@@ -62,12 +62,12 @@ module BlacklightConfig
 
       # Facet fields in the order they should be displayed.
       config.add_facet_field 'COLLECTION', include_in_request: false, single: true,
-                             values: ->(context) { context.displayable_collections.map { |collection| collection.key }.unshift('all') },
-                             default: 'all'
+                                           values: ->(context) { context.displayable_collections.map(&:key).unshift('all') },
+                                           default: 'all'
       config.add_facet_field 'api', include_in_request: false, single: true,
-                             when: ->(context) { context.within_collection? && context.current_collection.key == 'newspapers' },
-                             values: %w(collection default),
-                             default: 'collection'
+                                    when: ->(context) { context.within_collection? && context.current_collection.key == 'newspapers' },
+                                    values: %w(collection default),
+                                    default: 'collection'
       config.add_facet_field 'TYPE', hierarchical: true
       config.add_facet_field 'IMAGE_COLOUR', parent: %w(TYPE IMAGE)
       config.add_facet_field 'COLOURPALETTE', colour: true, hierarchical: true, parent: %w(TYPE IMAGE), limit: 20

--- a/app/controllers/concerns/catalog.rb
+++ b/app/controllers/concerns/catalog.rb
@@ -51,8 +51,9 @@ module Catalog
   end
 
   def search_action_path(options = {})
-    options[:only_path] = true
-    search_action_url(options)
+    opts = options.deep_symbolize_keys
+    opts[:only_path] = true
+    search_action_url(opts)
   end
 
   def search_action_url(options = {})

--- a/app/controllers/concerns/catalog.rb
+++ b/app/controllers/concerns/catalog.rb
@@ -50,12 +50,9 @@ module Catalog
     fail "Do not use Blacklight's search tracking."
   end
 
-  def search_action_path(*args)
-    if args[0].is_a?(Hash)
-      args[0] = args.first.symbolize_keys
-      args[0][:only_path] = true
-    end
-    search_action_url(*args)
+  def search_action_path(options = {})
+    options[:only_path] = true
+    search_action_url(options)
   end
 
   def search_action_url(options = {})

--- a/app/presenters/concerns/facet/item_display.rb
+++ b/app/presenters/concerns/facet/item_display.rb
@@ -19,16 +19,16 @@ module Facet
     def items_to_show_and_hide(**options)
       options.reverse_merge!(count: 5)
 
-      unhidden_items = []
-      hidden_items = items_to_display
+      show = []
+      hide = items_to_display
 
       unless facet_config.single
-        hidden_items.select { |item| facet_in_params?(facet_name, item) }.each do |selected_item|
-          unhidden_items << hidden_items.delete(selected_item)
+        hide.select { |item| facet_in_params?(facet_name, item) }.each do |selected_item|
+          show << hide.delete(selected_item)
         end
       end
-      unhidden_items.push(hidden_items.shift) while (unhidden_items.size < options[:count]) && hidden_items.present?
-      [unhidden_items, hidden_items]
+      show.push(hide.shift) while (show.size < options[:count]) && hide.present?
+      [show, hide]
     end
 
     # @return [Array<Europeana::Blacklight::Response::Facets::FacetItem>]

--- a/app/presenters/concerns/facet/item_display.rb
+++ b/app/presenters/concerns/facet/item_display.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+module Facet
+  module ItemDisplay
+    extend ActiveSupport::Concern
+
+    ##
+    # Splits the facet's items into two sets, one to be shown, the other hidden
+    #
+    # All currently selected facet items will be shown, regardless of the value of
+    # the `count` option.
+    #
+    # After all selected facet items, other non-selected facet items will be
+    # included in the set to show, up to a maximum set by the `count` option.
+    #
+    # All other items will be in the hidden set.
+    #
+    # @return [Array<Array>] Two arrays of facet items, first to show, last to hide
+    def items_to_show_and_hide(**options)
+      options.reverse_merge!(count: 5)
+
+      unhidden_items = []
+      hidden_items = items_to_display
+
+      unless facet_config.single
+        hidden_items.select { |item| facet_in_params?(facet_name, item) }.each do |selected_item|
+          unhidden_items << hidden_items.delete(selected_item)
+        end
+      end
+      unhidden_items.push(hidden_items.shift) while (unhidden_items.size < options[:count]) && hidden_items.present?
+      [unhidden_items, hidden_items]
+    end
+
+    # @return [Array<Europeana::Blacklight::Response::Facets::FacetItem>]
+    def items_to_display
+      items = facet_items.dup
+      %i{only order splice format_value_as}.each do |mod|
+        items = send(:"apply_#{mod}_to_items", items) if send(:"apply_#{mod}_to_items?")
+      end
+      items
+    end
+
+    def apply_only_to_items?
+      facet_config.only.present?
+    end
+
+    def apply_order_to_items?
+      false
+    end
+
+    def apply_splice_to_items?
+      facet_config.splice.present? && facet_config.parent.present?
+    end
+
+    def apply_format_value_as_to_items?
+      facet_config.format_value_as.present?
+    end
+
+    def apply_only_to_items(items)
+      items.select { |item| facet_config.only.call(item) }
+    end
+
+    def apply_order_to_items(items)
+      items
+    end
+
+    def apply_splice_to_items(items)
+      items.select { |item| facet_config.splice.call(@parent, item) } if facet_config.splice.present?
+    end
+
+    def apply_format_value_as_to_items(items)
+      items.map! do |item|
+        item.value = facet_config.format_value_as.call(item.value)
+        item
+      end
+    end
+  end
+end

--- a/app/presenters/concerns/facet/labelling.rb
+++ b/app/presenters/concerns/facet/labelling.rb
@@ -35,6 +35,7 @@ module Facet
                   items: {
                     with: ->(item) { Collection.find_by_key(item).title }
                   }
+      label_facet 'api', items: { i18n: true }
       label_facet 'TYPE', items: { titleize: false, i18n: true }
       label_facet 'IMAGE_COLOUR', items: { titleize: true, i18n: true }
       label_facet 'IMAGE_ASPECTRATIO', items: { titleize: true, i18n: true }

--- a/app/presenters/concerns/facet/url.rb
+++ b/app/presenters/concerns/facet/url.rb
@@ -67,7 +67,7 @@ module Facet
 
     def replace_facet_query(item)
       base = facet_item_url_base_query_params.deep_dup
-      base[:f].delete(facet_name) if base[:f]
+      base[:f]&.delete(facet_name)
       add_facet_query(item, base: base.to_query)
     end
 

--- a/app/presenters/concerns/facet/url.rb
+++ b/app/presenters/concerns/facet/url.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+module Facet
+  module URL
+    extend ActiveSupport::Concern
+
+    ##
+    # URL for a facet item to link to
+    #
+    # If the facet item is already selected, this URL will remove it. If not, it
+    # will add it.
+    #
+    # @param see {#facet_item}
+    # @return [String] URL to add/remove the facet item from the search
+    def facet_item_url(item)
+      if facet_config.single
+        replace_facet_url(item)
+      else
+        facet_in_params?(facet_name, item) ? remove_facet_url(item) : add_facet_url(item)
+      end
+    end
+
+    def add_facet_url(item)
+      rewrite_facet_url(:add, item)
+    end
+
+    def remove_facet_url(item)
+      rewrite_facet_url(:remove, item)
+    end
+
+    def replace_facet_url(item)
+      rewrite_facet_url(:replace, item)
+    end
+
+    def rewrite_facet_url(action, item)
+      path = send(:"#{action}_facet_path", item)
+      query = send(:"#{action}_facet_query", item)
+      [path, query].reject(&:blank?).join('?')
+    end
+
+    def add_facet_path(_item)
+      search_action_path
+    end
+
+    def remove_facet_path(_item)
+      search_action_path
+    end
+
+    def replace_facet_path(_item)
+      search_action_path
+    end
+
+    # @return [String] Request query string with the given facet item added
+    def add_facet_query(item, base: facet_item_url_base_query)
+      item_query = facet_cgi_query(facet_name, item.respond_to?(:value) ? item.value : item)
+      [base, add_facet_parent_query, item_query].reject(&:blank?).join('&')
+    end
+
+    ##
+    # Removes a facet item from request's query string
+    #
+    # @return [String] Request query string without the given facet item
+    def remove_facet_query(item)
+      item_query = Regexp.escape(facet_cgi_query(facet_name, item.respond_to?(:value) ? item.value : item))
+      facet_item_url_base_query.dup.sub(/#{item_query}&?/, '')
+    end
+
+    def replace_facet_query(item)
+      base = facet_item_url_base_query_params.deep_dup
+      base[:f].delete(facet_name) if base[:f]
+      add_facet_query(item, base: base.to_query)
+    end
+
+    def facet_item_url_base_query_params
+      @facet_item_url_base_query_params ||= params.slice(:q, :f, :per_page, :view, :range)
+    end
+
+    def facet_item_url_base_query
+      @facet_item_url_base_query ||= facet_item_url_base_query_params.to_query
+    end
+
+    def add_facet_parent_query
+      return @add_facet_parent_query if instance_variable_defined?(:@add_facet_parent_query)
+      @add_facet_parent_query = build_add_facet_parent_query
+    end
+
+    def build_add_facet_parent_query
+      return nil unless parent_facet.present?
+
+      facet_in_params?(parent_facet, @parent) ? nil : facet_cgi_query(parent_facet, @parent.value)
+    end
+
+    def facet_cgi_query(name, value)
+      [CGI.escape("f[#{name}][]"), CGI.escape(value)].join('=')
+    end
+  end
+end

--- a/app/presenters/facet/collection_presenter.rb
+++ b/app/presenters/facet/collection_presenter.rb
@@ -20,18 +20,10 @@ module Facet
       [search_url, facet_item_url_base_query].reject(&:blank?).join('?')
     end
 
-    def filter_items
-      items_in_params.reject { |item| default_facet_value?(item.value) }.map { |item| filter_item(item) }
-    end
-
     def facet_in_params?(field, item)
       value = facet_value_for_facet_item(item)
 
       facet_params(field) == value
-    end
-
-    def default_facet_value?(value)
-      value == default_facet_value
     end
 
     def default_facet_value

--- a/app/presenters/facet/collection_presenter.rb
+++ b/app/presenters/facet/collection_presenter.rb
@@ -3,9 +3,27 @@
 module Facet
   class CollectionPresenter < SimplePresenter
     def add_facet_url(item)
-      value = facet_value_for_facet_item(item)
-      base_url = default_facet_value?(value) ? search_url : collection_url(value)
-      [base_url, facet_item_url_base_query].join('?')
+      fail NotImplementedError
+    end
+
+    def remove_facet_path(_item)
+      search_path
+    end
+
+    def replace_facet_path(item)
+      default_facet_value?(item.value) ? search_path : collection_path(item.value)
+    end
+
+    def add_facet_query(item, base: facet_item_url_base_query)
+      fail NotImplementedError
+    end
+
+    def remove_facet_query(_item)
+      facet_item_url_base_query
+    end
+
+    def replace_facet_query(_item)
+      facet_item_url_base_query
     end
 
     def apply_order_to_items?
@@ -16,18 +34,12 @@ module Facet
       items.unshift(items.delete(items.detect { |item| facet_in_params?(facet_name, item) }))
     end
 
-    def remove_facet_url(_item)
-      [search_url, facet_item_url_base_query].reject(&:blank?).join('?')
+    def remove_facet_query(_item)
+      facet_item_url_base_query
     end
 
     def facet_in_params?(field, item)
-      value = facet_value_for_facet_item(item)
-
-      facet_params(field) == value
-    end
-
-    def default_facet_value
-      'all'
+      facet_params(field) == item.value
     end
 
     def facet_params(_field)

--- a/app/presenters/facet/collection_presenter.rb
+++ b/app/presenters/facet/collection_presenter.rb
@@ -2,7 +2,7 @@
 
 module Facet
   class CollectionPresenter < SimplePresenter
-    def add_facet_url(item)
+    def add_facet_url(_item)
       fail NotImplementedError
     end
 
@@ -14,7 +14,7 @@ module Facet
       default_facet_value?(item.value) ? search_path : collection_path(item.value)
     end
 
-    def add_facet_query(item, base: facet_item_url_base_query)
+    def add_facet_query(*_)
       fail NotImplementedError
     end
 
@@ -32,10 +32,6 @@ module Facet
 
     def apply_order_to_items(items, **_)
       items.unshift(items.delete(items.detect { |item| facet_in_params?(facet_name, item) }))
-    end
-
-    def remove_facet_query(_item)
-      facet_item_url_base_query
     end
 
     def facet_in_params?(field, item)

--- a/app/presenters/facet_presenter.rb
+++ b/app/presenters/facet_presenter.rb
@@ -192,6 +192,10 @@ class FacetPresenter < ApplicationPresenter
   ##
   # Sends missing method calls to the controller
   def method_missing(method, *args)
-    @controller.respond_to?(method, true) ? @controller.send(method, *args) : super
+    respond_to_missing?(method, true) ? @controller.send(method, *args) : super
+  end
+
+  def respond_to_missing?(method, _)
+    @controller.respond_to?(method, true) || super
   end
 end

--- a/app/views/concerns/searchable_view.rb
+++ b/app/views/concerns/searchable_view.rb
@@ -7,7 +7,7 @@ module SearchableView
 
   def form_search
     {
-      action: search_action_path(only_path: true)
+      action: search_action_path
     }.tap do |fs|
 
       # Auto-complete is not production ready. Only enable it on dev/test envs.

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -115,11 +115,21 @@ RSpec.describe CollectionsController do
 
               let(:collection) { collections(:newspapers) }
 
-              it 'is queried instead of default' do
-                get :show, params
-                expect(a_request(:get, "#{collection.api_url}/v2/search.json").
-                  with(query: hash_including(wskey: ENV['EUROPEANA_API_KEY']))).
-                  to have_been_made.at_least_once
+              context 'without api="default" facet in URL' do
+                it 'queries custom' do
+                  get :show, params
+                  expect(a_request(:get, "#{collection.api_url}/v2/search.json").
+                    with(query: hash_including(wskey: ENV['EUROPEANA_API_KEY']))).
+                    to have_been_made.at_least_once
+                end
+              end
+
+              context 'with api="default" facet in URL' do
+                let(:params) { { locale: 'en', id: collection.key, q: 'search', format: format, f: { api: ['default'] } } }
+                it 'queries default' do
+                  get :show, params
+                  expect(an_api_search_request).to have_been_made.at_least_once
+                end
               end
             end
           end

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -105,14 +105,7 @@ RSpec.describe CollectionsController do
             end
 
             context 'when collection has custom API URL' do
-              before do
-                stub_request(:get, "#{collection.api_url}/v2/search.json").
-                  with(query: hash_including(wskey: ENV['EUROPEANA_API_KEY'])).
-                  to_return(body: api_responses(:search),
-                            status: 200,
-                            headers: { 'Content-Type' => 'application/json' })
-              end
-
+              include_context :collection_with_custom_api_url
               let(:collection) { collections(:newspapers) }
 
               context 'without api="default" facet in URL' do

--- a/spec/features/collection_search_spec.rb
+++ b/spec/features/collection_search_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.feature 'Collection search page' do
   [false, true].each do |js|
     context (js ? 'with JS' : 'without JS'), js: js do

--- a/spec/features/newspapers_collection_spec.rb
+++ b/spec/features/newspapers_collection_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+RSpec.feature 'Newspapers collection' do
+  let(:collection) { collections(:newspapers) }
+  include_context :collection_with_custom_api_url
+
+  describe 'search' do
+    it 'has an API toggle' do
+      visit collection_path(collection, locale: 'en', q: '')
+
+      expect(page).to have_css('.filter-list a.is-checked .filter-text', text: 'Fulltext')
+      expect(page).to have_css('.filter-list a:not(.is-checked) .filter-text', text: 'Metadata')
+    end
+  end
+end

--- a/spec/features/newspapers_collection_spec.rb
+++ b/spec/features/newspapers_collection_spec.rb
@@ -8,8 +8,8 @@ RSpec.feature 'Newspapers collection' do
     it 'has an API toggle' do
       visit collection_path(collection, locale: 'en', q: '')
 
-      expect(page).to have_css('.filter-list a.is-checked .filter-text', text: 'Fulltext')
-      expect(page).to have_css('.filter-list a:not(.is-checked) .filter-text', text: 'Metadata')
+      expect(page).to have_css('.filter-list a.is-checked .filter-text', text: I18n.t('global.facet.api.collection'))
+      expect(page).to have_css('.filter-list a:not(.is-checked) .filter-text', text: I18n.t('global.facet.api.default'))
     end
   end
 end

--- a/spec/presenters/facet/collection_presenter_spec.rb
+++ b/spec/presenters/facet/collection_presenter_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Facet::CollectionPresenter, presenter: :facet do
   let(:field_name) { 'COLLECTION' }
-  let(:field_options) { {} }
+  let(:field_options) { { single: true } }
   let(:params) { { id: 'performing-arts' } }
 
   it_behaves_like 'a text-labelled facet item presenter'

--- a/spec/support/shared_contexts/collection_with_custom_api_url.rb
+++ b/spec/support/shared_contexts/collection_with_custom_api_url.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+RSpec.shared_context :collection_with_custom_api_url do
+  before do
+    stub_request(:get, "#{collection.api_url}/v2/search.json").
+      with(query: hash_including(wskey: ENV['EUROPEANA_API_KEY'])).
+      to_return(body: api_responses(:search),
+                status: 200,
+                headers: { 'Content-Type' => 'application/json' })
+  end
+end


### PR DESCRIPTION
To introduce a pseudo-facet for the Newspapers collection to switch between its custom API and the default, this:
* abstracts some of the collection-facet-specific presentation logic to be reusable across single-selection (i.e. radio button) facets, and pseudo-facets not in fact sent to the API
* breaks the `FacetPresenter` class's methods down into more modules
* adds an "api" facet to the "newspapers" collection
* skips the use of a per-collection API in the collection search if this facet has the value "default" selected (as in default API, not default radio button)
* outputs URL paths instead of full URLs for facet links, to reduce page weight